### PR TITLE
Reduce memory allocations

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -76,6 +76,9 @@ processResources {
         exclude 'mcmod.info'
         exclude 'license.txt'
     }
+
+    //adds the AT file(s)
+    rename '(.+_at.cfg)', 'META-INF/$1'
 }
 
 task processDocs(type: Copy) {
@@ -146,6 +149,9 @@ task unlimitedJar(type: Jar, dependsOn: ['copyCss', 'deleteNoRadar', 'processDoc
         include 'mcmod.info'
         expand 'version': project.version, 'mcversion': project.minecraft.version, 'forgeversion': config.forge_version, jmedition: config.unlimited
     }
+    manifest {
+        attributes 'FMLAT': 'journeymap_at.cfg'
+    }
 }
 
 task fairPlayJar(type: Jar, dependsOn: ['copyCss', 'deleteNoRadar', 'deleteUnlimited', 'processDocs']) {
@@ -157,6 +163,9 @@ task fairPlayJar(type: Jar, dependsOn: ['copyCss', 'deleteNoRadar', 'deleteUnlim
     from(sourceSets.main.resources.srcDirs) {
         include 'mcmod.info'
         expand 'version': project.version, 'mcversion': project.minecraft.version, 'forgeversion': config.forge_version, jmedition: config.fairPlay
+    }
+    manifest {
+        attributes 'FMLAT': 'journeymap_at.cfg'
     }
 }
 

--- a/src/main/java/journeymap/client/cartography/ChunkPainter.java
+++ b/src/main/java/journeymap/client/cartography/ChunkPainter.java
@@ -22,7 +22,7 @@ public class ChunkPainter
     public static final int COLOR_VOID = RGB.toInteger(17, 12, 25);
     protected static volatile AtomicLong badBlockCount = new AtomicLong(0);
 
-    Integer[][] colors = new Integer[16][16];
+    int[][] colors = new int[16][16];
     Graphics2D g2D;
 
     public ChunkPainter(Graphics2D g2D)
@@ -36,8 +36,8 @@ public class ChunkPainter
      */
     public void paintDimOverlay(int x, int z, float alpha)
     {
-        Integer color = colors[x][z];
-        if (color != null)
+        int color = colors[x][z];
+        if (color != -1)
         {
             paintBlock(x, z, RGB.adjustBrightness(color, alpha));
         }
@@ -86,7 +86,7 @@ public class ChunkPainter
      */
     public void finishPainting()
     {
-        Integer color;
+        int color;
         int lastColor = -1;
 
         try
@@ -96,7 +96,7 @@ public class ChunkPainter
                 for (int x = 0; x < 16; x++)
                 {
                     color = colors[x][z];
-                    if (color == null)
+                    if (color == -1)
                     {
                         continue;
                     }
@@ -117,6 +117,14 @@ public class ChunkPainter
             g2D.dispose();
             g2D = null;
             colors = null;
+        }
+    }
+
+    public void initColorsArray(){
+        for (int x=0; x < 16;x++) {
+            for (int z=0;z<16;z++){
+                colors[x][z]=-1;
+            }
         }
     }
 }

--- a/src/main/java/journeymap/client/cartography/MutableChunkCoordIntPair.java
+++ b/src/main/java/journeymap/client/cartography/MutableChunkCoordIntPair.java
@@ -1,0 +1,20 @@
+package journeymap.client.cartography;
+
+import net.minecraft.world.ChunkCoordIntPair;
+
+public class MutableChunkCoordIntPair extends ChunkCoordIntPair {
+
+    public MutableChunkCoordIntPair(int p_i1947_1_, int p_i1947_2_) {
+        super(p_i1947_1_, p_i1947_2_);
+
+    }
+
+    public MutableChunkCoordIntPair setChunkXPos(int chunkXPos){
+        this.chunkXPos = chunkXPos;
+        return this;
+    }
+    public MutableChunkCoordIntPair setChunkZPos(int chunkZPos){
+        this.chunkZPos = chunkZPos;
+        return this;
+    }
+}

--- a/src/main/java/journeymap/client/cartography/PixelPaint.java
+++ b/src/main/java/journeymap/client/cartography/PixelPaint.java
@@ -22,7 +22,7 @@ class PixelPaint implements Paint, PaintContext
 {
     final ColorModel colorModel = ColorModel.getRGBdefault();
     IntegerComponentRaster intRaster;
-    Integer rgbColor;
+    int rgbColor;
 
     /**
      * Sets the rgb color to use.

--- a/src/main/java/journeymap/client/cartography/render/BaseRenderer.java
+++ b/src/main/java/journeymap/client/cartography/render/BaseRenderer.java
@@ -498,16 +498,15 @@ public abstract class BaseRenderer implements IChunkRenderer, RemovalListener<Ch
     {
         final int blockX = (chunkMd.getCoord().chunkXPos << 4) + (x + offset.x);
         final int blockZ = (chunkMd.getCoord().chunkZPos << 4) + (z + offset.z);
-        final ChunkCoordIntPair targetCoord = new ChunkCoordIntPair(blockX >> 4, blockZ >> 4);
-        ChunkMD targetChunkMd = null;
+        ChunkMD targetChunkMd;
 
-        if (targetCoord.equals(chunkMd.getCoord()))
+        if (blockX >> 4 == chunkMd.getCoord().chunkXPos && blockZ >> 4 == chunkMd.getCoord().chunkXPos)
         {
             targetChunkMd = chunkMd;
         }
         else
         {
-            targetChunkMd = dataCache.getChunkMD(targetCoord);
+            targetChunkMd = dataCache.getChunkMD(new ChunkCoordIntPair(blockX >> 4, blockZ >> 4));
         }
 
         if (targetChunkMd != null)

--- a/src/main/java/journeymap/client/cartography/render/BaseRenderer.java
+++ b/src/main/java/journeymap/client/cartography/render/BaseRenderer.java
@@ -9,6 +9,7 @@ package journeymap.client.cartography.render;
 import com.google.common.cache.*;
 import journeymap.client.JourneymapClient;
 import journeymap.client.cartography.IChunkRenderer;
+import journeymap.client.cartography.MutableChunkCoordIntPair;
 import journeymap.client.cartography.RGB;
 import journeymap.client.cartography.Stratum;
 import journeymap.client.data.DataCache;
@@ -35,6 +36,7 @@ import java.util.HashMap;
 public abstract class BaseRenderer implements IChunkRenderer, RemovalListener<ChunkCoordIntPair, ChunkMD>
 {
     public static final String PROP_WATER_HEIGHT = "waterHeight";
+    private static final MutableChunkCoordIntPair coordinates = new MutableChunkCoordIntPair(0, 0);
     protected static final AlphaComposite ALPHA_OPAQUE = AlphaComposite.getInstance(AlphaComposite.SRC_OVER, 1F);
     protected static final int COLOR_BLACK = Color.black.getRGB();
     protected static final int COLOR_VOID = RGB.toInteger(17, 12, 25);
@@ -289,16 +291,15 @@ public abstract class BaseRenderer implements IChunkRenderer, RemovalListener<Ch
     {
         final int blockX = (chunkMd.getCoord().chunkXPos << 4) + (x + offset.x);
         final int blockZ = (chunkMd.getCoord().chunkZPos << 4) + (z + offset.z);
-        final ChunkCoordIntPair targetCoord = new ChunkCoordIntPair(blockX >> 4, blockZ >> 4);
-        ChunkMD targetChunkMd = null;
+        ChunkMD targetChunkMd;
 
-        if (targetCoord.equals(chunkMd.getCoord()))
+        if (blockX >> 4 == chunkMd.getCoord().chunkXPos && blockZ >> 4 == chunkMd.getCoord().chunkZPos)
         {
             targetChunkMd = chunkMd;
         }
         else
         {
-            targetChunkMd = dataCache.getChunkMD(targetCoord);
+            targetChunkMd = dataCache.getChunkMD(coordinates.setChunkXPos(blockX >> 4).setChunkZPos(blockZ >> 4));
         }
 
         if (targetChunkMd != null)
@@ -506,7 +507,7 @@ public abstract class BaseRenderer implements IChunkRenderer, RemovalListener<Ch
         }
         else
         {
-            targetChunkMd = dataCache.getChunkMD(new ChunkCoordIntPair(blockX >> 4, blockZ >> 4));
+            targetChunkMd = dataCache.getChunkMD(coordinates.setChunkXPos(blockX >> 4).setChunkZPos(blockZ >> 4));
         }
 
         if (targetChunkMd != null)

--- a/src/main/resources/journeymap_at.cfg
+++ b/src/main/resources/journeymap_at.cfg
@@ -1,0 +1,2 @@
+public-f net.minecraft.world.ChunkCoordIntPair field_77276_a # chunkXPos
+public-f net.minecraft.world.ChunkCoordIntPair field_77275_b # chunkZPos


### PR DESCRIPTION
Supersedes https://github.com/TeamJM/journeymap-legacy/pull/11. Tested in a flat world in dev:
before:
![image](https://github.com/TeamJM/journeymap-legacy/assets/12850933/8ec207ab-8667-4a02-b173-f1a4fb00038d)

after: 
![image](https://github.com/TeamJM/journeymap-legacy/assets/12850933/31055c35-599e-4d47-a477-173334742a3c)

Some optimisations could be done further by replacing the ChunkCoordIntPairs key in the cache by longs, but it's too big of a rewrite.

Also, the biggest offender is from `sun.java2d.SunGraphics2D.fillRect(int, int, int, int)`: 
![image](https://github.com/TeamJM/journeymap-legacy/assets/12850933/e3214efd-3c3b-4ae4-a5bc-737d307f029b)

It's particularly innefficient, but trying to reduce calls by drawing lines of the same colors here resulted in way more allocations internally. https://github.com/TeamJM/journeymap-legacy/blob/4d5b5e2dce92f703deb2e93f9bea79ebb8b31ca6/src/main/java/journeymap/client/cartography/ChunkPainter.java#L88-L114 

