### PR TITLE
Fix wrong changelog and missing version display names in MN/CF publications

### DIFF
--- a/.github/workflows/release-tags.yml
+++ b/.github/workflows/release-tags.yml
@@ -59,14 +59,8 @@ jobs:
           if [[ "$SNAPSHOT" == "true" ]]; then
             PRERELEASE="--prerelease"
           fi
-          export "CHANGELOG_FILE=$(mktemp --suffix=.md)"
-          echo "CHANGELOG_FILE=${CHANGELOG_FILE}" >> $GITHUB_ENV
-          gh api --method POST -H "Accept: application/vnd.github+json" \
-            "/repos/${GITHUB_REPOSITORY}/releases/generate-notes" \
-            -f tag_name="${RELEASE_VERSION}" \
-            --jq ".body" > "${CHANGELOG_FILE}"
-          cat "${CHANGELOG_FILE}"
-          gh release create "${RELEASE_VERSION}" -F "${CHANGELOG_FILE}" $PRERELEASE ./build/libs/*.jar
+          ./gradlew --build-cache --stacktrace processDocs
+          gh release create "${RELEASE_VERSION}" -F "build/doc/changelog.html" $PRERELEASE ./build/libs/*.jar
         shell: bash
         continue-on-error: true
         env:

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -131,13 +131,26 @@ publishing.publications.withType<MavenPublication> {
 
 pluginManager.withPlugin("com.modrinth.minotaur") {
     val modrinth = project.extensions.getByType<ModrinthExtension>()
+    modrinth.versionName = "${mod_id}-${minecraft_version}-${project.version}"
     modrinth.additionalFiles.add(fairPlayJar)
     if (project.file("/build/doc/changelog.html").exists())
         modrinth.changelog = project.file("/build/doc/changelog.html").readText(Charsets.UTF_8)
+    processDocs {
+        doLast {
+            // If the task executes, update the changelog in Minotaur as it doesn't support passing in a File
+            modrinth.changelog = project.file("/build/doc/changelog.html").readText(Charsets.UTF_8)
+        }
+    }
+    tasks.named("modrinth") {
+        dependsOn(processDocs)
+    }
 }
 
 tasks.publishCurseforge {
+    dependsOn(processDocs)
+
     val mainArtifact = this.uploadArtifacts[0]
+    mainArtifact.displayName = "${mod_id}-${minecraft_version}-${project.version}"
     mainArtifact.releaseType = curse_release_type
     mainArtifact.changelogType = "html"
     mainArtifact.changelog = project.file("/build/doc/changelog.html")


### PR DESCRIPTION
This should fix the version naming issue, and uploading the wrong changelog.