### PR TITLE
Improve map grid size handling, fix fullscreen map cutting off

### DIFF
--- a/src/main/java/journeymap/client/render/map/GridRenderer.java
+++ b/src/main/java/journeymap/client/render/map/GridRenderer.java
@@ -74,11 +74,6 @@ public class GridRenderer
     private FloatBuffer winPosBuf;
     private FloatBuffer objPosBuf;
 
-    @Deprecated
-    public GridRenderer(int gridSize) {
-        this();
-    }
-
     public GridRenderer()
     {
         viewportBuf = BufferUtils.createIntBuffer(16);
@@ -164,8 +159,7 @@ public class GridRenderer
         return gridSize;
     }
 
-    // TODO: This shouldn't be public anymore, as grid size is now automatically calculated on each update
-    public void setGridSize(int gridSize)
+    private void setGridSize(int gridSize)
     {
         if (this.gridSize == gridSize) return;
         this.gridSize = gridSize;  // Must be an odd number so as to have a center tile.

--- a/src/main/java/journeymap/client/ui/fullscreen/Fullscreen.java
+++ b/src/main/java/journeymap/client/ui/fullscreen/Fullscreen.java
@@ -67,7 +67,7 @@ import java.util.List;
 public class Fullscreen extends JmUI
 {
     final static MapState state = new MapState();
-    final static GridRenderer gridRenderer = new GridRenderer(5);
+    final static GridRenderer gridRenderer = new GridRenderer();
     final WaypointDrawStepFactory waypointRenderer = new WaypointDrawStepFactory();
     final RadarDrawStepFactory radarRenderer = new RadarDrawStepFactory();
     final LayerDelegate layerDelegate = new LayerDelegate();

--- a/src/main/java/journeymap/client/ui/minimap/MiniMap.java
+++ b/src/main/java/journeymap/client/ui/minimap/MiniMap.java
@@ -48,7 +48,7 @@ public class MiniMap
     private static final float lightmapS = (float) (15728880 % 65536) / 1f;
     private static final float lightmapT = (float) (15728880 / 65536) / 1f;
     private static final long labelRefreshRate = 400;
-    private final static GridRenderer gridRenderer = new GridRenderer(3);
+    private final static GridRenderer gridRenderer = new GridRenderer();
     private final IForgeHelper forgeHelper = ForgeHelper.INSTANCE;
     private final Logger logger = Journeymap.getLogger();
     private final Minecraft mc = ForgeHelper.INSTANCE.getClient();
@@ -98,8 +98,6 @@ public class MiniMap
 
         MapType mapType = state.getMapType(showCaves);
 
-        int gridSize = miniMapProperties.getSize() <= 768 ? 3 : 5;
-        gridRenderer.setGridSize(gridSize);
         gridRenderer.setContext(state.getWorldDir(), mapType);
         gridRenderer.center(mapType, mc.thePlayer.posX, mc.thePlayer.posZ, miniMapProperties.zoomLevel.get());
 


### PR DESCRIPTION
First commit makes the grid size dynamic instead of a constant 5x5. Fixes #34 

Other 2 commits clean things up and make the grid able to be non-square, e.g. 5 tiles in width and 3 tiles in height.
This should reduce the amount of work done. when playing in fullscreen on a 1920x1080 screen, only 3x5=15 tiles are used instead of 5x5=25.
I have not benchmarked the actual impact of this as I'm not sure how to do this here.
These also create changes in `public` functions, which may count as a breaking (major version increase) change, depending on your versioning.
If these other things are unwanted, I can drop the commits.

All changes are tested ingame. Proper review and testing would still be appreciated as i find this codebase a bit confusing.