### PR TITLE
fix grid size calculation formula

### DIFF
--- a/src/main/java/journeymap/client/render/map/GridRenderer.java
+++ b/src/main/java/journeymap/client/render/map/GridRenderer.java
@@ -590,8 +590,8 @@ public class GridRenderer
     }
 
     private void updateGridSize() {
-        int newGridSizeHeight = (int) Math.ceil(screenBounds.height / Tile.TILESIZE + 0.5);
-        int newGridSizeWidth = (int) Math.ceil(screenBounds.width / Tile.TILESIZE + 0.5);
+        int newGridSizeHeight = (int) Math.ceil(screenBounds.height / Tile.TILESIZE) + 1;
+        int newGridSizeWidth = (int) Math.ceil(screenBounds.width / Tile.TILESIZE) + 1;
 
         setGridSizes(newGridSizeHeight, newGridSizeWidth);
     }


### PR DESCRIPTION
Closes #36
Uses the safer formula for calculating grid size (which might overestimate required tile count for some resolutions).
Tested around grid boundaries at smaller resolutions as well now to confirm the issue is resolved.