### PR TITLE
Fix image copying for custom color types

### DIFF
--- a/doc/changelog.html
+++ b/doc/changelog.html
@@ -24,4 +24,5 @@
 <p>New in ${version}</p>
 <ul>
     <li>Fixed: Some PNGs fail to resize.</li>
+    <li>Chore: Update buildscript.</li>
 </ul>

--- a/doc/changelog.html
+++ b/doc/changelog.html
@@ -23,5 +23,5 @@
 
 <p>New in ${version}</p>
 <ul>
-    <li>Fixed: Minimap not always showing full map tiles.</li>
+    <li>Fixed: Some PNGs fail to resize.</li>
 </ul>

--- a/gradle.properties
+++ b/gradle.properties
@@ -79,6 +79,11 @@ accessTransformersFile = journeymap_at.cfg
 # Provides setup for Mixins if enabled. If you don't know what mixins are: Keep it disabled!
 usesMixins = false
 
+# Set to a non-empty string to configure mixins in a separate source set under src/VALUE, instead of src/main.
+# This can speed up compile times thanks to not running the mixin annotation processor on all input sources.
+# Mixin classes will have access to "main" classes, but not the other way around.
+separateMixinSourceSet =
+
 # Adds some debug arguments like verbose output and class export.
 usesMixinDebug = false
 
@@ -111,8 +116,14 @@ minimizeShadowedDependencies = false
 # If disabled, won't rename the shadowed classes.
 relocateShadowedDependencies = true
 
-# Adds the GTNH maven, CurseMaven, IC2/Player maven, and some more well-known 1.7.10 repositories.
+# Adds CurseMaven, Modrinth, and some more well-known 1.7.10 repositories.
 includeWellKnownRepositories = true
+
+# A list of repositories to exclude from the includeWellKnownRepositories setting. Should be a space separated
+# list of strings, with the acceptable keys being(case does not matter):
+# cursemaven
+# modrinth
+excludeWellKnownRepositories =
 
 # Change these to your Maven coordinates if you want to publish to a custom Maven repository instead of the default GTNH Maven.
 # Authenticate with the MAVEN_USER and MAVEN_PASSWORD environment variables.
@@ -149,7 +160,7 @@ curseForgeProjectId = 32274
 #       and the name is the CurseForge project slug of the other mod.
 # Example: requiredDependency:railcraft;embeddedLibrary:cofhlib;incompatible:buildcraft
 # Note: UniMixins is automatically set as a required dependency if usesMixins = true.
-curseForgeRelations = tool:journeymap-tools
+curseForgeRelations = tool\:journeymap-tools
 
 # Optional parameter to customize the produced artifacts. Use this to preserve artifact naming when migrating older
 # projects. New projects should not use this parameter.

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.6-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/settings.gradle
+++ b/settings.gradle
@@ -17,5 +17,5 @@ pluginManagement {
 }
 
 plugins {
-    id 'com.gtnewhorizons.gtnhsettingsconvention' version '1.0.17'
+    id 'com.gtnewhorizons.gtnhsettingsconvention' version '1.0.30'
 }

--- a/src/main/java/journeymap/client/render/texture/TextureCache.java
+++ b/src/main/java/journeymap/client/render/texture/TextureCache.java
@@ -5,6 +5,7 @@
 
 package journeymap.client.render.texture;
 
+import javax.imageio.ImageTypeSpecifier;
 import journeymap.client.io.FileHandler;
 import journeymap.client.io.IconSetFileHandler;
 import journeymap.client.io.RegionImageHandler;
@@ -36,11 +37,11 @@ import java.util.concurrent.*;
  */
 public class TextureCache
 {
-    private final Map<Name, TextureImpl> namedTextures = Collections.synchronizedMap(new HashMap<Name, TextureImpl>(Name.values().length + (Name.values().length / 2) + 1));
-    //private final Map<String, TextureImpl> customTextures = Collections.synchronizedMap(new HashMap<String, TextureImpl>(3));
-    private final Map<String, TextureImpl> playerSkins = Collections.synchronizedMap(new HashMap<String, TextureImpl>());
-    private final Map<String, TextureImpl> entityIcons = Collections.synchronizedMap(new HashMap<String, TextureImpl>());
-    private final Map<String, TextureImpl> themeImages = Collections.synchronizedMap(new HashMap<String, TextureImpl>());
+    private final Map<Name, TextureImpl> namedTextures = Collections.synchronizedMap(new HashMap<>(Name.values().length + (Name.values().length / 2) + 1));
+    //private final Map<String, TextureImpl> customTextures = Collections.synchronizedMap(new HashMap<>(3));
+    private final Map<String, TextureImpl> playerSkins = Collections.synchronizedMap(new HashMap<>());
+    private final Map<String, TextureImpl> entityIcons = Collections.synchronizedMap(new HashMap<>());
+    private final Map<String, TextureImpl> themeImages = Collections.synchronizedMap(new HashMap<>());
 
     private ThreadPoolExecutor texExec = new ThreadPoolExecutor(2, 4, 15L, TimeUnit.SECONDS,
             new ArrayBlockingQueue<Runnable>(8), new JMThreadFactory("texture"), new ThreadPoolExecutor.CallerRunsPolicy());
@@ -322,7 +323,7 @@ public class TextureCache
                     {
                         if (alpha < 1f || img.getWidth() != width || img.getHeight() != height)
                         {
-                            BufferedImage tmp = new BufferedImage(width, height, img.getType());
+                            BufferedImage tmp = ImageTypeSpecifier.createFromRenderedImage(img).createBufferedImage(width, height);
                             Graphics2D g = tmp.createGraphics();
                             g.setComposite(AlphaComposite.getInstance(AlphaComposite.SRC_OVER, alpha));
                             g.setRenderingHint(RenderingHints.KEY_INTERPOLATION, RenderingHints.VALUE_INTERPOLATION_BICUBIC);
@@ -363,7 +364,7 @@ public class TextureCache
                 {
                     if (alpha < 1f || img.getWidth() != width || img.getHeight() != height)
                     {
-                        BufferedImage tmp = new BufferedImage(width, height, img.getType());
+                        BufferedImage tmp = ImageTypeSpecifier.createFromRenderedImage(img).createBufferedImage(width, height);
                         Graphics2D g = tmp.createGraphics();
                         g.setComposite(AlphaComposite.getInstance(AlphaComposite.SRC_OVER, alpha));
                         g.setRenderingHint(RenderingHints.KEY_INTERPOLATION, RenderingHints.VALUE_INTERPOLATION_BICUBIC);
@@ -424,7 +425,8 @@ public class TextureCache
                 BufferedImage img = downloadSkin(username);
                 if (img != null)
                 {
-                    final BufferedImage scaledImage = new BufferedImage(24, 24, img.getType());
+                    final BufferedImage scaledImage =
+                            ImageTypeSpecifier.createFromRenderedImage(img).createBufferedImage(24, 24);
                     final Graphics2D g = RegionImageHandler.initRenderingHints(scaledImage.createGraphics());
                     g.drawImage(img, 0, 0, 24, 24, null);
                     g.dispose();


### PR DESCRIPTION
Use ImageTypeSpecifier to copy images instead of manually doing it, fixing images with custom color types.