### PR TITLE
fix: Color data is properly loaded

### DIFF
--- a/src/main/resources/assets/journeymap/web/colorpalette.html
+++ b/src/main/resources/assets/journeymap/web/colorpalette.html
@@ -87,6 +87,43 @@
         var count = 0;
         var table = colorpalette.table;
 
+        if (table === undefined && colorpalette.basicColors !== undefined) {
+            table = Object.fromEntries(
+                colorpalette.basicColors
+                .reduce(
+                    (collector, basicColor) => {
+                        var parts = basicColor.uid.split(/:/, 2);
+
+                        if (!collector.has(parts[0])) {
+                            collector.set(parts[0], new Map());
+                        }
+                        var blocks = collector.get(parts[0]);
+
+                        if (!blocks.has(parts[1])) {
+                            blocks.set(parts[1], new Map());
+                        }
+                        var states = blocks.get(parts[1]);
+
+                        states.set(basicColor.meta, [basicColor.color, basicColor.alpha]);
+
+                        return collector;
+                    },
+                    new Map()
+                )
+                .entries()
+                .map(([mod, blocks]) => ([
+                    mod,
+                    Object.fromEntries(blocks
+                        .entries()
+                        .map(([block, states]) => ([
+                            block,
+                            Object.fromEntries(states.entries())
+                        ]))
+                    )
+                ]))
+            )
+        }
+
         for (var mod in table) {
             var modEl = document.createElement("div");
             modEl.className = "mod";


### PR DESCRIPTION
Original issue raised from usage in GTNH modpack.
The data format generated in `colorPalette.json` is different from what is expected by this file script. The data still available and just required some refactor. Instead of `colorPalette.table`, a refactor of `colorPalette.basicColors` can be used. This refactor runs only when needed (just in case the previous format is in use somehow).