### PR TITLE
Optimize minecraft loading time

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ tmp/
 .idea/
 eclipse/
 out/
+.DS_Store
 journeymap.iml
 journeymap.ipr
 journeymap.iws

--- a/doc/changelog.html
+++ b/doc/changelog.html
@@ -23,5 +23,5 @@
 
 <p>New in ${version}</p>
 <ul>
-    <li>Performance: reduce JourneyMap startup time by up to 4x</li>
+    <li>Performance: reduce JourneyMap startup time by up to 4x. (danyadev)</li>
 </ul>

--- a/doc/changelog.html
+++ b/doc/changelog.html
@@ -23,5 +23,5 @@
 
 <p>New in ${version}</p>
 <ul>
-    <li>Added: Waypoint Fade options.</li>
+    <li>Performance: reduce JourneyMap startup time by up to 4x</li>
 </ul>

--- a/src/main/java/journeymap/client/cartography/ColorManager.java
+++ b/src/main/java/journeymap/client/cartography/ColorManager.java
@@ -180,7 +180,6 @@ public class ColorManager
             {
                 Journeymap.getLogger().info(String.format("Initialized %s block colors from mods and resource packs in %sms", count, elapsed));
                 this.currentPalette = ColorPalette.create(standard, permanent);
-                Journeymap.getLogger().info(String.format("Updated color palette file: %s", this.currentPalette.getOrigin()));
             }
             else
             {

--- a/src/main/java/journeymap/client/cartography/ColorPalette.java
+++ b/src/main/java/journeymap/client/cartography/ColorPalette.java
@@ -415,7 +415,7 @@ public class ColorPalette
     }
 
 
-    class BlockColor implements Comparable<BlockColor>
+    static class BlockColor implements Comparable<BlockColor>
     {
         @Since(1)
         String name;
@@ -439,8 +439,9 @@ public class ColorPalette
             this.uid = GameData.getBlockRegistry().getNameForObject(blockMD.getBlock()).toString();
             this.meta = blockMD.getMeta();
 
-            Color awtColor = new Color(intColor);
-            this.color = String.format("#%02x%02x%02x", awtColor.getRed(), awtColor.getGreen(), awtColor.getBlue());
+            String hex = Integer.toHexString(intColor & 0xFFFFFF);
+            this.color = "#" + "000000".substring(hex.length()) + hex;
+
             if (blockMD.getAlpha() < 1f)
             {
                 this.alpha = blockMD.getAlpha();

--- a/src/main/java/journeymap/client/cartography/ColorPalette.java
+++ b/src/main/java/journeymap/client/cartography/ColorPalette.java
@@ -108,7 +108,7 @@ public class ColorPalette
         lines.add(Constants.getString("jm.colorpalette.file_header_3", JSON_FILENAME, SAMPLE_WORLD_PATH));
         lines.add(Constants.getString("jm.colorpalette.file_header_4", JSON_FILENAME, SAMPLE_STANDARD_PATH));
         lines.add(Constants.getString("jm.config.file_header_5", HELP_PAGE));
-        this.description = lines.toArray(new String[4]);
+        this.description = lines.toArray(new String[0]);
 
         this.basicColors = toList(basicColorMap);
     }
@@ -266,13 +266,10 @@ public class ColorPalette
         {
             BlockMD blockMD = entry.getKey();
             Integer color = entry.getValue();
-            if (blockMD == null || color == null)
-            {
-                continue;
-            }
+
             if (blockMD.hasFlag(BlockMD.Flag.Error))
             {
-                Journeymap.getLogger().warn("Block with Error flag won't be saved to color palette: " + entry.getKey());
+                Journeymap.getLogger().warn("Block with Error flag won't be saved to color palette: " + blockMD);
             }
             else
             {
@@ -337,7 +334,8 @@ public class ColorPalette
                 Float alpha = blockColor.alpha;
                 blockMD.setAlpha((alpha != null) ? alpha : 1f);
             }
-            int color = RGB.ALPHA_OPAQUE | Integer.parseInt(blockColor.color.replaceFirst("#", ""), 16);
+            // substring #
+            int color = RGB.ALPHA_OPAQUE | Integer.parseInt(blockColor.color.substring(1), 16);
             map.put(blockMD, color);
         }
         return map;

--- a/src/main/java/journeymap/client/cartography/ColorPalette.java
+++ b/src/main/java/journeymap/client/cartography/ColorPalette.java
@@ -9,6 +9,7 @@ import com.google.common.io.Files;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.annotations.Since;
+import com.google.gson.stream.JsonWriter;
 import cpw.mods.fml.common.Loader;
 import cpw.mods.fml.common.registry.GameData;
 import journeymap.client.Constants;
@@ -23,8 +24,12 @@ import net.minecraft.block.Block;
 import net.minecraft.client.Minecraft;
 
 import java.awt.*;
+import java.io.BufferedReader;
 import java.io.File;
+import java.io.FileInputStream;
 import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.Writer;
 import java.nio.charset.Charset;
 import java.util.*;
 import java.util.regex.Matcher;
@@ -221,11 +226,11 @@ public class ColorPalette
 
     private static ColorPalette loadFromFile(File file)
     {
-        String jsonString = null;
-        try
+        try (BufferedReader reader = new BufferedReader(new InputStreamReader(new FileInputStream(file), UTF8)))
         {
-            jsonString = Files.toString(file, UTF8).replaceFirst(VARIABLE, "");
-            ColorPalette palette = GSON.fromJson(jsonString, ColorPalette.class);
+            reader.skip(VARIABLE.length());
+
+            ColorPalette palette = GSON.fromJson(reader, ColorPalette.class);
             palette.origin = file;
 
             // Ensure current HTML file accompanies the data
@@ -284,8 +289,15 @@ public class ColorPalette
         {
             // Write JSON
             palleteFile = standard ? getStandardPaletteFile() : getWorldPaletteFile();
-            Files.write(VARIABLE + GSON.toJson(this), palleteFile, UTF8);
             this.origin = palleteFile;
+
+            try (Writer out = Files.newWriter(palleteFile, UTF8);
+                 JsonWriter jsonWriter = new JsonWriter(out))
+            {
+                out.write(VARIABLE);
+                jsonWriter.setIndent("  ");
+                GSON.toJson(this, this.getClass(), jsonWriter);
+            }
 
             // Write HTML
             getOriginHtml(true, true);

--- a/src/main/java/journeymap/client/cartography/ColorPalette.java
+++ b/src/main/java/journeymap/client/cartography/ColorPalette.java
@@ -53,7 +53,7 @@ public class ColorPalette
 
     public static final int VERSION = 3;
     public static final Gson GSON = new GsonBuilder().setVersion(VERSION).setPrettyPrinting().create();
-    private static final ExecutorService writeExecutor = Executors.newSingleThreadExecutor(new JMThreadFactory("ColorPaletteWrite"));
+    private static final JMThreadFactory writeThreadFactory = new JMThreadFactory("ColorPaletteWrite");
 
     @Since(3)
     int version;
@@ -202,8 +202,9 @@ public class ColorPalette
             }
 
             ColorPalette palette = new ColorPalette(resourcePackNames, modPackNames, baseColors);
+            palette.origin = standard ? getStandardPaletteFile() : getWorldPaletteFile();
             palette.setPermanent(permanent);
-            palette.writeToFileAsync(standard);
+            palette.writeToFileAsync();
             Journeymap.getLogger().info("Queued color palette file with {} colors for: {}", palette.size(), palette.getOrigin());
             return palette;
         }
@@ -280,37 +281,29 @@ public class ColorPalette
         return list;
     }
 
-    private boolean writeToFile(boolean standard)
+    private void writeToFile()
     {
-        File palleteFile = null;
-        try
+        // Write JSON
+        try (Writer out = Files.newWriter(origin, UTF8);
+             JsonWriter jsonWriter = new JsonWriter(out))
         {
-            // Write JSON
-            palleteFile = standard ? getStandardPaletteFile() : getWorldPaletteFile();
-            this.origin = palleteFile;
-
-            try (Writer out = Files.newWriter(palleteFile, UTF8);
-                 JsonWriter jsonWriter = new JsonWriter(out))
-            {
-                out.write(VARIABLE);
-                jsonWriter.setIndent("  ");
-                GSON.toJson(this, this.getClass(), jsonWriter);
-            }
-
-            // Write HTML
-            getOriginHtml(true, true);
-            return true;
+            out.write(VARIABLE);
+            jsonWriter.setIndent("  ");
+            GSON.toJson(this, this.getClass(), jsonWriter);
         }
         catch (Exception e)
         {
-            Journeymap.getLogger().error(String.format("Can't save color pallete file %s: %s", palleteFile, LogFormatter.toString(e)));
-            return false;
+            Journeymap.getLogger().error("Can't save color pallete file {}: {}", origin, LogFormatter.toString(e));
+            return;
         }
+
+        // Write HTML
+        getOriginHtml(true, true);
     }
 
-    private void writeToFileAsync(final boolean standard)
+    private void writeToFileAsync()
     {
-        writeExecutor.submit(() -> writeToFile(standard));
+        writeThreadFactory.newThread(this::writeToFile).start();
     }
 
     private HashMap<BlockMD, Integer> listToMap(ArrayList<BlockColor> list)

--- a/src/main/java/journeymap/client/cartography/ColorPalette.java
+++ b/src/main/java/journeymap/client/cartography/ColorPalette.java
@@ -20,6 +20,7 @@ import journeymap.client.log.ChatLog;
 import journeymap.client.log.LogFormatter;
 import journeymap.client.model.BlockMD;
 import journeymap.common.Journeymap;
+import journeymap.common.thread.JMThreadFactory;
 import net.minecraft.block.Block;
 import net.minecraft.client.Minecraft;
 
@@ -31,7 +32,10 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.Writer;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.*;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.regex.Matcher;
 
 /**
@@ -45,10 +49,11 @@ public class ColorPalette
     public static final String JSON_FILENAME = "colorpalette.json";
     public static final String HTML_FILENAME = "colorpalette.html";
     public static final String VARIABLE = "var colorpalette=";
-    public static final Charset UTF8 = Charset.forName("UTF-8");
+    public static final Charset UTF8 = StandardCharsets.UTF_8;
 
     public static final int VERSION = 3;
     public static final Gson GSON = new GsonBuilder().setVersion(VERSION).setPrettyPrinting().create();
+    private static final ExecutorService writeExecutor = Executors.newSingleThreadExecutor(new JMThreadFactory("ColorPaletteWrite"));
 
     @Since(3)
     int version;
@@ -181,9 +186,6 @@ public class ColorPalette
      */
     public static ColorPalette create(boolean standard, boolean permanent)
     {
-        long start = System.currentTimeMillis();
-
-        ColorPalette palette = null;
         try
         {
             String resourcePackNames = Constants.getResourcePackNames();
@@ -199,11 +201,10 @@ public class ColorPalette
                 }
             }
 
-            palette = new ColorPalette(resourcePackNames, modPackNames, baseColors);
+            ColorPalette palette = new ColorPalette(resourcePackNames, modPackNames, baseColors);
             palette.setPermanent(permanent);
-            palette.writeToFile(standard);
-            long elapsed = System.currentTimeMillis() - start;
-            Journeymap.getLogger().info(String.format("Color palette file generated with %d colors in %dms for: %s", palette.size(), elapsed, palette.getOrigin()));
+            palette.writeToFileAsync(standard);
+            Journeymap.getLogger().info("Queued color palette file with {} colors for: {}", palette.size(), palette.getOrigin());
             return palette;
         }
         catch (Exception e)
@@ -310,6 +311,10 @@ public class ColorPalette
         }
     }
 
+    private void writeToFileAsync(final boolean standard)
+    {
+        writeExecutor.submit(() -> writeToFile(standard));
+    }
 
     private HashMap<BlockMD, Integer> listToMap(ArrayList<BlockColor> list)
     {

--- a/src/main/java/journeymap/client/forge/helper/impl/ColorHelper_1_7_10.java
+++ b/src/main/java/journeymap/client/forge/helper/impl/ColorHelper_1_7_10.java
@@ -34,7 +34,7 @@ import java.util.HashSet;
  */
 public class ColorHelper_1_7_10 implements IColorHelper
 {
-    private static volatile BufferedImage blocksTexture;
+    private static volatile ArgbImage blocksTexture;
     Logger logger = Journeymap.getLogger();
     HashSet<BlockMD> failed = new HashSet<BlockMD>();
 
@@ -242,13 +242,13 @@ public class ColorHelper_1_7_10 implements IColorHelper
                 logger.warn("Couldn't get texture for " + icon.getIconName() + " because of an error matching it within the stitched blocks atlas.");
                 return null;
             }
-            BufferedImage textureImg = blocksTexture.getSubimage(icon.getOriginX(), icon.getOriginY(), icon.getIconWidth(), icon.getIconHeight());
+            ArgbImage textureImg = blocksTexture.getSubimage(icon.getOriginX(), icon.getOriginY(), icon.getIconWidth(), icon.getIconHeight());
             xStart = yStart = 0;
             xStop = textureImg.getWidth();
             yStop = textureImg.getHeight();
 
             boolean unusable = true;
-            if (textureImg != null && textureImg.getWidth() > 0)
+            if (textureImg.getWidth() > 0)
             {
                 outer:
                 for (x = xStart; x < xStop; x++)
@@ -394,9 +394,10 @@ public class ColorHelper_1_7_10 implements IColorHelper
             int[] aint = new int[width * height];
             GL11.glGetTexImage(GL11.GL_TEXTURE_2D, miplevel, GL12.GL_BGRA, GL12.GL_UNSIGNED_INT_8_8_8_8_REV, intbuffer);
             intbuffer.get(aint);
-            BufferedImage bufferedimage = new BufferedImage(width, height, 2);
-            bufferedimage.setRGB(0, 0, width, height, aint, 0, width);
-            blocksTexture = bufferedimage;
+
+            ArgbImage argbImage = new ArgbImage(width, height);
+            argbImage.setRGB(0, 0, width, height, aint, 0, width);
+            blocksTexture = argbImage;
 
             double time = timer.stop();
             Journeymap.getLogger().info(String.format("initBlocksTexture: %sx%s loaded in %sms", width, height, time));
@@ -414,7 +415,7 @@ public class ColorHelper_1_7_10 implements IColorHelper
     /**
      * Facade to expose IIcon as a TextureAtlasSprite.
      */
-    class TempTextureAtlasSprite extends TextureAtlasSprite
+    public static class TempTextureAtlasSprite extends TextureAtlasSprite
     {
         IIcon wrapped;
 
@@ -446,6 +447,72 @@ public class ColorHelper_1_7_10 implements IColorHelper
         public int getIconHeight()
         {
             return wrapped.getIconHeight();
+        }
+    }
+
+    /**
+     * Minimal ARGB image implementation for fast pixel access.
+     * Avoids overhead of {@link BufferedImage#setRGB} since we store and use ARGB pixels only.
+     */
+    private static final class ArgbImage {
+        public final int[] pixels;
+        public final int width;
+        public final int height;
+        public final int stride;
+        public final int offset;
+
+        public ArgbImage(int width, int height) {
+            this(new int[width * height], width, height, width, 0);
+        }
+
+        public ArgbImage(int[] pixels, int width, int height, int stride, int offset) {
+            this.pixels = pixels;
+            this.width = width;
+            this.height = height;
+            this.stride = stride;
+            this.offset = offset;
+        }
+
+        public int getWidth() {
+            return width;
+        }
+        public int getHeight() {
+            return height;
+        }
+
+        public int getRGB(int x, int y) {
+            return pixels[offset + y * stride + x];
+        }
+
+        public void setRGB(int x, int y, int argb) {
+            pixels[offset + y * stride + x] = argb;
+        }
+
+        public void setRGB(int x, int y, int w, int h, int[] srcPixels, int srcOffset, int srcStride) {
+            if (x < 0 || y < 0 || w < 0 || h < 0 || x + w > width || y + h > height) {
+                throw new IllegalArgumentException("Region out of bounds");
+            }
+            if (w == 0 || h == 0) {
+                return;
+            }
+
+            // Fast path: both source and destination are tightly packed
+            if (x == 0 && y == 0 && w == width && h == height && srcStride == width && stride == width) {
+                System.arraycopy(srcPixels, srcOffset, pixels, offset, width * height);
+                return;
+            }
+
+            int dst = offset + y * stride + x;
+            for (int row = 0; row < h; row++) {
+                System.arraycopy(srcPixels, srcOffset + row * srcStride, pixels, dst + row * stride, w);
+            }
+        }
+
+        public ArgbImage getSubimage(int x, int y, int w, int h) {
+            if (x < 0 || y < 0 || w < 0 || h < 0 || x + w > width || y + h > height) {
+                throw new IllegalArgumentException("Subimage out of bounds");
+            }
+            return new ArgbImage(pixels, w, h, stride, offset + y * stride + x);
         }
     }
 }

--- a/src/main/java/journeymap/client/model/BlockMD.java
+++ b/src/main/java/journeymap/client/model/BlockMD.java
@@ -19,6 +19,7 @@ import journeymap.common.Journeymap;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockAir;
 import net.minecraft.init.Blocks;
+import net.minecraft.init.Items;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 
@@ -258,7 +259,6 @@ public class BlockMD
     public static Collection<Integer> getMetaValuesForBlock(Block block)
     {
         ArrayList<Integer> metas = new ArrayList<Integer>();
-        ArrayList<ItemStack> subBlocks = new ArrayList<ItemStack>();
         try
         {
             Item item = Item.getItemFromBlock(block);
@@ -268,10 +268,11 @@ public class BlockMD
             }
             else
             {
+                ArrayList<ItemStack> subBlocks = new ArrayList<ItemStack>();
                 block.getSubBlocks(item, null, subBlocks);
                 for (ItemStack subBlockStack : subBlocks)
                 {
-                    metas.add(subBlockStack.getItemDamage());
+                    metas.add(Items.feather.getDamage(subBlockStack));
                 }
             }
         }

--- a/src/main/java/journeymap/client/model/BlockMD.java
+++ b/src/main/java/journeymap/client/model/BlockMD.java
@@ -34,6 +34,7 @@ public class BlockMD
     public static final EnumSet FlagsPlantAndCrop = EnumSet.of(Flag.Plant, Flag.Crop);
     public static final EnumSet FlagsBiomeColored = EnumSet.of(Flag.Grass, Flag.Foliage, Flag.Water, Flag.CustomBiomeColor);
     private static final Map<Block, Map<Integer, BlockMD>> cache = new HashMap<Block, Map<Integer, BlockMD>>();
+    private static final Map<Block, ArrayList<Integer>> blockMetaCache = new HashMap<>();
     public static BlockMD AIRBLOCK;
     public static BlockMD VOIDBLOCK;
     private static ModBlockDelegate modBlockDelegate = new ModBlockDelegate();
@@ -258,6 +259,9 @@ public class BlockMD
      */
     public static Collection<Integer> getMetaValuesForBlock(Block block)
     {
+        ArrayList<Integer> cached = blockMetaCache.get(block);
+        if (cached != null) return cached;
+
         ArrayList<Integer> metas = new ArrayList<Integer>();
         try
         {
@@ -280,6 +284,8 @@ public class BlockMD
         {
             Journeymap.getLogger().error("Couldn't get subblocks for block " + block + ": " + e);
         }
+
+        blockMetaCache.put(block, metas);
         return metas;
     }
 
@@ -297,7 +303,7 @@ public class BlockMD
         List<BlockMD> list = new ArrayList<BlockMD>(metas.size());
         for (int meta : metas)
         {
-            list.add(BlockMD.get(block, meta));
+            list.add(BlockMD.get(block, meta, metas.size()));
         }
         return list;
     }

--- a/src/main/java/journeymap/client/model/BlockMD.java
+++ b/src/main/java/journeymap/client/model/BlockMD.java
@@ -19,7 +19,6 @@ import journeymap.common.Journeymap;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockAir;
 import net.minecraft.init.Blocks;
-import net.minecraft.init.Items;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 
@@ -276,7 +275,7 @@ public class BlockMD
                 block.getSubBlocks(item, null, subBlocks);
                 for (ItemStack subBlockStack : subBlocks)
                 {
-                    metas.add(Items.feather.getDamage(subBlockStack));
+                    metas.add(subBlockStack.getItemDamage());
                 }
             }
         }

--- a/src/main/java/journeymap/client/model/BlockMD.java
+++ b/src/main/java/journeymap/client/model/BlockMD.java
@@ -275,7 +275,9 @@ public class BlockMD
                 block.getSubBlocks(item, null, subBlocks);
                 for (ItemStack subBlockStack : subBlocks)
                 {
-                    metas.add(subBlockStack.getItemDamage());
+                    // Item.getDamage(ItemStack) is an equivalent of ItemStack.getItemDamage() but faster,
+                    // because we're skipping the Item delegate lookup which would always return the same Item
+                    metas.add(item.getDamage(subBlockStack));
                 }
             }
         }

--- a/src/main/java/journeymap/client/model/mod/BiomesOPlenty.java
+++ b/src/main/java/journeymap/client/model/mod/BiomesOPlenty.java
@@ -35,7 +35,7 @@ public class BiomesOPlenty implements ModBlockDelegate.IModBlockHandler
     {
 
         boolean initialized = false;
-        if (blockMD.getUid().modId.equalsIgnoreCase("BiomesOPlenty"))
+        if (blockMD.getUid().modId.equals("BiomesOPlenty"))
         {
             String name = blockMD.getUid().name.toLowerCase();
 //            if (name.contains("grass"))

--- a/src/main/java/journeymap/client/model/mod/Miscellaneous.java
+++ b/src/main/java/journeymap/client/model/mod/Miscellaneous.java
@@ -14,9 +14,8 @@ import journeymap.client.waypoint.WaypointStore;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.tileentity.TileEntity;
 
-import java.awt.*;
-import java.util.ArrayList;
-import java.util.List;
+import java.awt.Color;
+import java.util.HashSet;
 
 import static journeymap.client.model.BlockMD.Flag.*;
 
@@ -35,7 +34,7 @@ public class Miscellaneous
         // Thaumcraft leaves (greatwood, silverwood)
         GameRegistry.UniqueIdentifier thaumcraftLeavesId = new GameRegistry.UniqueIdentifier("Thaumcraft:blockMagicalLeaves");
 
-        List<GameRegistry.UniqueIdentifier> torches = new ArrayList<GameRegistry.UniqueIdentifier>();
+        HashSet<GameRegistry.UniqueIdentifier> torches = new HashSet<>();
 
         public CommonHandler()
         {

--- a/src/main/java/journeymap/client/model/mod/vanilla/VanillaBlockHandler.java
+++ b/src/main/java/journeymap/client/model/mod/vanilla/VanillaBlockHandler.java
@@ -5,8 +5,6 @@
 
 package journeymap.client.model.mod.vanilla;
 
-import com.google.common.collect.ListMultimap;
-import com.google.common.collect.MultimapBuilder;
 import journeymap.client.JourneymapClient;
 import journeymap.client.model.BlockMD;
 import journeymap.client.model.ChunkMD;
@@ -19,6 +17,7 @@ import net.minecraft.init.Blocks;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.Map;
 
 import static journeymap.client.model.BlockMD.Flag.*;
 
@@ -27,14 +26,14 @@ import static journeymap.client.model.BlockMD.Flag.*;
  */
 public final class VanillaBlockHandler implements ModBlockDelegate.IModBlockHandler
 {
-    ListMultimap<Material, BlockMD.Flag> materialFlags = MultimapBuilder.ListMultimapBuilder.linkedHashKeys().arrayListValues().build();
-    ListMultimap<Class<? extends Block>, BlockMD.Flag> blockClassFlags = MultimapBuilder.ListMultimapBuilder.linkedHashKeys().arrayListValues().build();
-    ListMultimap<Block, BlockMD.Flag> blockFlags = MultimapBuilder.ListMultimapBuilder.linkedHashKeys().arrayListValues().build();
-    HashMap<Material, Float> materialAlphas = new HashMap<Material, Float>();
-    HashMap<Block, Float> blockAlphas = new HashMap<Block, Float>();
-    HashMap<Class<? extends Block>, Float> blockClassAlphas = new HashMap<Class<? extends Block>, Float>();
-    HashMap<Block, Integer> blockTextureSides = new HashMap<Block, Integer>();
-    HashMap<Class<? extends Block>, Integer> blockClassTextureSides = new HashMap<Class<? extends Block>, Integer>();
+    private final HashMap<Material, ArrayList<BlockMD.Flag>> materialFlags = new HashMap<Material, ArrayList<BlockMD.Flag>>();
+    private final HashMap<Class<? extends Block>, ArrayList<BlockMD.Flag>> blockClassFlags = new HashMap<Class<? extends Block>, ArrayList<BlockMD.Flag>>();
+    private final HashMap<Block, ArrayList<BlockMD.Flag>> blockFlags = new HashMap<Block, ArrayList<BlockMD.Flag>>();
+    private final HashMap<Material, Float> materialAlphas = new HashMap<Material, Float>();
+    private final HashMap<Block, Float> blockAlphas = new HashMap<Block, Float>();
+    private final HashMap<Class<? extends Block>, Float> blockClassAlphas = new HashMap<Class<? extends Block>, Float>();
+    private final HashMap<Block, Integer> blockTextureSides = new HashMap<Block, Integer>();
+    private final HashMap<Class<? extends Block>, Integer> blockClassTextureSides = new HashMap<Class<? extends Block>, Integer>();
 
     public VanillaBlockHandler()
     {
@@ -106,7 +105,11 @@ public final class VanillaBlockHandler implements ModBlockDelegate.IModBlockHand
 
         // Set flags based on material
         Material material = blockMD.getBlock().getMaterial();
-        blockMD.addFlags(materialFlags.get(material));
+        ArrayList<BlockMD.Flag> materialFlagList = materialFlags.get(material);
+        if (materialFlagList != null)
+        {
+            blockMD.addFlags(materialFlagList);
+        }
 
         // Set alpha based on material
         Float alpha = materialAlphas.get(material);
@@ -117,9 +120,10 @@ public final class VanillaBlockHandler implements ModBlockDelegate.IModBlockHand
 
         // Set flags based on exact block
         Block block = blockMD.getBlock();
-        if (blockFlags.containsKey(block))
+        ArrayList<BlockMD.Flag> blockFlagList = blockFlags.get(block);
+        if (blockFlagList != null)
         {
-            blockMD.addFlags(blockFlags.get(block));
+            blockMD.addFlags(blockFlagList);
         }
 
         // Set alpha based on exact block
@@ -132,11 +136,12 @@ public final class VanillaBlockHandler implements ModBlockDelegate.IModBlockHand
         // Add flags based on block class inheritance
         if (blockMD.getFlags().isEmpty())
         {
-            for (Class<? extends Block> parentClass : blockClassFlags.keys())
+            for (Map.Entry<Class<? extends Block>, ArrayList<BlockMD.Flag>> entry : blockClassFlags.entrySet())
             {
+                Class<? extends Block> parentClass = entry.getKey();
                 if (parentClass.isAssignableFrom(block.getClass()))
                 {
-                    blockMD.addFlags(blockClassFlags.get(parentClass));
+                    blockMD.addFlags(entry.getValue());
                     alpha = blockClassAlphas.get(parentClass);
                     if (alpha != null)
                     {
@@ -197,7 +202,8 @@ public final class VanillaBlockHandler implements ModBlockDelegate.IModBlockHand
 
     private void setFlags(Material material, BlockMD.Flag... flags)
     {
-        materialFlags.putAll(material, new ArrayList<BlockMD.Flag>(Arrays.asList(flags)));
+        materialFlags.computeIfAbsent(material, k -> new ArrayList<>())
+            .addAll(Arrays.asList(flags));
     }
 
     private void setFlags(Material material, Float alpha, BlockMD.Flag... flags)
@@ -208,7 +214,8 @@ public final class VanillaBlockHandler implements ModBlockDelegate.IModBlockHand
 
     private void setFlags(Class<? extends Block> parentClass, BlockMD.Flag... flags)
     {
-        blockClassFlags.putAll(parentClass, new ArrayList<BlockMD.Flag>(Arrays.asList(flags)));
+        blockClassFlags.computeIfAbsent(parentClass, k -> new ArrayList<>())
+            .addAll(Arrays.asList(flags));
     }
 
     private void setFlags(Class<? extends Block> parentClass, Float alpha, BlockMD.Flag... flags)
@@ -219,7 +226,8 @@ public final class VanillaBlockHandler implements ModBlockDelegate.IModBlockHand
 
     private void setFlags(Block block, BlockMD.Flag... flags)
     {
-        blockFlags.putAll(block, new ArrayList<BlockMD.Flag>(Arrays.asList(flags)));
+        blockFlags.computeIfAbsent(block, k -> new ArrayList<>())
+            .addAll(Arrays.asList(flags));
     }
 
     private void setFlags(Block block, Float alpha, BlockMD.Flag... flags)

--- a/src/main/java/journeymap/client/model/mod/vanilla/VanillaBlockHandler.java
+++ b/src/main/java/journeymap/client/model/mod/vanilla/VanillaBlockHandler.java
@@ -17,6 +17,7 @@ import net.minecraft.init.Blocks;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 import static journeymap.client.model.BlockMD.Flag.*;
@@ -27,7 +28,7 @@ import static journeymap.client.model.BlockMD.Flag.*;
 public final class VanillaBlockHandler implements ModBlockDelegate.IModBlockHandler
 {
     private final HashMap<Material, ArrayList<BlockMD.Flag>> materialFlags = new HashMap<Material, ArrayList<BlockMD.Flag>>();
-    private final HashMap<Class<? extends Block>, ArrayList<BlockMD.Flag>> blockClassFlags = new HashMap<Class<? extends Block>, ArrayList<BlockMD.Flag>>();
+    private final HashMap<Class<? extends Block>, ArrayList<BlockMD.Flag>> blockClassFlags = new LinkedHashMap<Class<? extends Block>, ArrayList<BlockMD.Flag>>();
     private final HashMap<Block, ArrayList<BlockMD.Flag>> blockFlags = new HashMap<Block, ArrayList<BlockMD.Flag>>();
 
     private final HashMap<Material, Float> materialAlphas = new HashMap<Material, Float>();

--- a/src/main/java/journeymap/client/model/mod/vanilla/VanillaBlockHandler.java
+++ b/src/main/java/journeymap/client/model/mod/vanilla/VanillaBlockHandler.java
@@ -29,11 +29,15 @@ public final class VanillaBlockHandler implements ModBlockDelegate.IModBlockHand
     private final HashMap<Material, ArrayList<BlockMD.Flag>> materialFlags = new HashMap<Material, ArrayList<BlockMD.Flag>>();
     private final HashMap<Class<? extends Block>, ArrayList<BlockMD.Flag>> blockClassFlags = new HashMap<Class<? extends Block>, ArrayList<BlockMD.Flag>>();
     private final HashMap<Block, ArrayList<BlockMD.Flag>> blockFlags = new HashMap<Block, ArrayList<BlockMD.Flag>>();
+
     private final HashMap<Material, Float> materialAlphas = new HashMap<Material, Float>();
     private final HashMap<Block, Float> blockAlphas = new HashMap<Block, Float>();
     private final HashMap<Class<? extends Block>, Float> blockClassAlphas = new HashMap<Class<? extends Block>, Float>();
+
     private final HashMap<Block, Integer> blockTextureSides = new HashMap<Block, Integer>();
     private final HashMap<Class<? extends Block>, Integer> blockClassTextureSides = new HashMap<Class<? extends Block>, Integer>();
+
+    private final HashMap<Class<? extends Block>, Class<? extends Block>> cachedParentClasses = new HashMap<Class<? extends Block>, Class<? extends Block>>();
 
     public VanillaBlockHandler()
     {
@@ -136,26 +140,17 @@ public final class VanillaBlockHandler implements ModBlockDelegate.IModBlockHand
         // Add flags based on block class inheritance
         if (blockMD.getFlags().isEmpty())
         {
-            for (Map.Entry<Class<? extends Block>, ArrayList<BlockMD.Flag>> entry : blockClassFlags.entrySet())
+            Class<? extends Block> parentClass = getParentClass(block.getClass());
+            if (parentClass != null)
             {
-                Class<? extends Block> parentClass = entry.getKey();
-                if (parentClass.isAssignableFrom(block.getClass()))
-                {
-                    blockMD.addFlags(entry.getValue());
-                    alpha = blockClassAlphas.get(parentClass);
-                    if (alpha != null)
-                    {
-                        blockMD.setAlpha(alpha);
-                    }
+                ArrayList<BlockMD.Flag> flags = blockClassFlags.get(parentClass);
+                if (flags != null) blockMD.addFlags(flags);
 
-                    Integer textureSide = blockClassTextureSides.get(parentClass);
-                    if (textureSide != null)
-                    {
-                        blockMD.setTextureSide(textureSide);
-                    }
+                alpha = blockClassAlphas.get(parentClass);
+                if (alpha != null) blockMD.setAlpha(alpha);
 
-                    break;
-                }
+                Integer classTextureSide = blockClassTextureSides.get(parentClass);
+                if (classTextureSide != null) blockMD.setTextureSide(classTextureSide);
             }
         }
 
@@ -244,5 +239,27 @@ public final class VanillaBlockHandler implements ModBlockDelegate.IModBlockHand
     private void setTextureSide(Block block, int side)
     {
         blockTextureSides.put(block, side);
+    }
+
+    // Class.isAssignableFrom is slow, so we cache resolved class connections
+    private Class<? extends Block> getParentClass(Class<? extends Block> blockClass)
+    {
+        if (cachedParentClasses.containsKey(blockClass))
+        {
+            return cachedParentClasses.get(blockClass);
+        }
+
+        for (Map.Entry<Class<? extends Block>, ArrayList<BlockMD.Flag>> entry : blockClassFlags.entrySet())
+        {
+            Class<? extends Block> parentClass = entry.getKey();
+            if (parentClass.isAssignableFrom(blockClass))
+            {
+                cachedParentClasses.put(blockClass, parentClass);
+                return parentClass;
+            }
+        }
+
+        cachedParentClasses.put(blockClass, null);
+        return null;
     }
 }


### PR DESCRIPTION
This PR is focused on optimizing everything down the `JourneymapClient.performMainThreadTasks` branch.

Here are the Before and After profiles, showing more than 2x performance boost, in other words `performMainThreadTasks` is 61% faster
| Before | After |
|:-:|:-:|
| <img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/abde3f16-1dcf-47c1-b2d2-8eccb09e5a35" /> | <img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/93c2e8ec-6b6b-4acb-95ba-0dfe937bd7db" /> |
| 1097ms total / 455ms the left branch | 863ms total / 176ms the left branch |

Note: instant would mean it takes less than 0.25ms so my async profiler couldn't catch it.
Profiled & tested in GregTech: New Horizons, daily 458, using macbook M1

### minor perf improvements
* `ItemStack.getItemDamage()` is a bit slower than `Items.feather.getDamage(subBlockStack)` because the former spends some time on `getItem()`. 1.25ms -> instant
* `HashSet` is obviously faster than `ArrayList` for `.contains` operations. 2.75ms -> 0.5ms

### replace ListMultimap to HashMap and use fast entrySet
* 25.5ms for `ListMultimap` iterator -> instant for `HashMap.entrySet`

### cache parent classes to avoid slow .isAssignableFrom calls
* 33.25ms for raw `Class.isAssignableFrom` -> 2.5ms for cached implementation

### reduce BufferedImage overhead
* 103.5ms `BufferedImage` -> 9.25ms `ArgbImage`

### use buffered read / write
* affected only read: 30ms `Files.toString` + 15ms `Gson.fromJson` = 45ms -> 16ms combined buffered read. String building is really slow

### async palette file write
* it made write completely free, -40ms

### faster hex generation
* 13ms -> 2.5ms

### faster listToMap
* not really... 3.75ms `replaceFirst` -> 2.25ms `substring`

### cache block meta
* `getMetaValuesForBlock` time: 28.5ms -> 8.5ms