### PR TITLE
Fix biome label update delay on minimap

### DIFF
--- a/doc/changelog.html
+++ b/doc/changelog.html
@@ -23,5 +23,5 @@
 
 <p>New in ${version}</p>
 <ul>
-    <li>Performance: reduce JourneyMap startup time by up to 4x. (danyadev)</li>
+    <li>Fix: biome label under minimap compass now updates instantly instead of with up to ~1400ms delay. (Eldrinn-Elantey)</li>
 </ul>

--- a/src/main/java/journeymap/client/ui/minimap/MiniMap.java
+++ b/src/main/java/journeymap/client/ui/minimap/MiniMap.java
@@ -26,6 +26,7 @@ import journeymap.client.render.texture.TextureCache;
 import journeymap.client.render.texture.TextureImpl;
 import journeymap.common.Journeymap;
 import net.minecraft.client.Minecraft;
+import net.minecraft.world.biome.BiomeGenBase;
 import net.minecraft.client.renderer.OpenGlHelper;
 import net.minecraft.client.renderer.RenderHelper;
 import net.minecraft.entity.player.EntityPlayer;
@@ -661,7 +662,7 @@ public class MiniMap
         {
             if (mc.theWorld != null && mc.thePlayer != null)
             {
-                net.minecraft.world.biome.BiomeGenBase biome = mc.theWorld.getBiomeGenForCoords(
+                BiomeGenBase biome = mc.theWorld.getBiomeGenForCoords(
                     MathHelper.floor_double(mc.thePlayer.posX),
                     MathHelper.floor_double(mc.thePlayer.posZ)
                 );

--- a/src/main/java/journeymap/client/ui/minimap/MiniMap.java
+++ b/src/main/java/journeymap/client/ui/minimap/MiniMap.java
@@ -659,7 +659,14 @@ public class MiniMap
         // Biome key
         if (dv.showBiome)
         {
-            biomeLabelText = state.getPlayerBiome();
+            if (mc.theWorld != null && mc.thePlayer != null)
+            {
+                net.minecraft.world.biome.BiomeGenBase biome = mc.theWorld.getBiomeGenForCoords(
+                    MathHelper.floor_double(mc.thePlayer.posX),
+                    MathHelper.floor_double(mc.thePlayer.posZ)
+                );
+                biomeLabelText = biome != null ? biome.biomeName : "?";
+            }
         }
 
         // Time key


### PR DESCRIPTION
## Problem
The biome name displayed under the minimap compass was updated with up to ~1400ms delay due to two cache layers:
- PlayerData cache TTL: 1000ms
- Label refresh rate: 400ms

## Solution
Replaced `state.getPlayerBiome()` (reads from cached `PlayerData`) with a direct call to `mc.theWorld.getBiomeGenForCoords()`, which is the same approach used by InGame-Info-XML.

Added null-check for `mc.theWorld` and `mc.thePlayer` to handle the main menu state safely.

## Result
Biome label now reflects the actual biome with ~400ms delay instead of ~1400ms.