### PR TITLE
Fix: Remove dependency on internal sun.awt.image.IntegerComponentRaster

### DIFF
--- a/doc/changelog.html
+++ b/doc/changelog.html
@@ -23,5 +23,6 @@
 
 <p>New in ${version}</p>
 <ul>
+    <li>Fix: biome label under minimap compass now updates instantly instead of with up to ~1400ms delay. (Eldrinn-Elantey)</li>
     <li>Fix: replace internal sun.awt.image.IntegerComponentRaster with standard Java API in PixelPaint. (Eldrinn-Elantey)</li>
 </ul>

--- a/doc/changelog.html
+++ b/doc/changelog.html
@@ -23,5 +23,5 @@
 
 <p>New in ${version}</p>
 <ul>
-    <li>Fix: biome label under minimap compass now updates instantly instead of with up to ~1400ms delay. (Eldrinn-Elantey)</li>
+    <li>Fix: replace internal sun.awt.image.IntegerComponentRaster with standard Java API in PixelPaint. (Eldrinn-Elantey)</li>
 </ul>

--- a/doc/changelog.html
+++ b/doc/changelog.html
@@ -23,5 +23,5 @@
 
 <p>New in ${version}</p>
 <ul>
-    <li>Performance: reduce JourneyMap startup time by up to 4x. (danyadev)</li>
+    <li>Fix: biome label under minimap compass now updates instantly instead of with up to ~1400ms delay. (Eldrinn-Elantey)</li>
 </ul>

--- a/src/main/java/journeymap/client/cartography/PixelPaint.java
+++ b/src/main/java/journeymap/client/cartography/PixelPaint.java
@@ -5,13 +5,13 @@
 
 package journeymap.client.cartography;
 
-import sun.awt.image.IntegerComponentRaster;
-
 import java.awt.*;
 import java.awt.geom.AffineTransform;
 import java.awt.geom.Rectangle2D;
 import java.awt.image.ColorModel;
+import java.awt.image.DataBufferInt;
 import java.awt.image.Raster;
+import java.awt.image.WritableRaster;
 import java.util.Arrays;
 
 /**
@@ -21,7 +21,8 @@ import java.util.Arrays;
 class PixelPaint implements Paint, PaintContext
 {
     final ColorModel colorModel = ColorModel.getRGBdefault();
-    IntegerComponentRaster intRaster;
+    WritableRaster intRaster;
+    int[] rasterData;
     int rgbColor;
 
     /**
@@ -62,20 +63,23 @@ class PixelPaint implements Paint, PaintContext
     {
         synchronized (this)
         {
-            IntegerComponentRaster raster = this.intRaster;
+            WritableRaster raster = this.intRaster;
+            int[] data = this.rasterData;
 
             if (raster == null || w > raster.getWidth() || h > raster.getHeight())
             {
-                raster = (IntegerComponentRaster) getColorModel().createCompatibleWritableRaster(w, h);
+                raster = getColorModel().createCompatibleWritableRaster(w, h);
+                data = ((DataBufferInt) raster.getDataBuffer()).getData();
 
                 // Only reuse if the raster is for a single pixel
                 if (w == 1 && h == 1)
                 {
                     this.intRaster = raster;
+                    this.rasterData = data;
                 }
             }
 
-            Arrays.fill(raster.getDataStorage(), this.rgbColor);
+            Arrays.fill(data, this.rgbColor);
 
             return raster;
         }


### PR DESCRIPTION
## Problem
`PixelPaint` imported and cast to `sun.awt.image.IntegerComponentRaster` to access the backing `int[]` array via `getDataStorage()`. This is a JDK-internal proprietary API — inaccessible under strict module settings and subject to removal in future Java releases.

## Solution
- Replaced `IntegerComponentRaster` field with `WritableRaster`
- Added a `int[] rasterData` field to hold a direct reference to the buffer
- After creating the raster via `getColorModel().createCompatibleWritableRaster()`, extract its `DataBufferInt` via `raster.getDataBuffer()` — safe because `ColorModel.getRGBdefault()` always produces `DataBufferInt`-backed rasters
- `Arrays.fill` now targets the extracted `int[]` directly

## Result
No `sun.*` imports. Compiler warnings eliminated. Behavior is identical.