### PR TITLE
[Memory-opti:runtime allocations] Reduce runtime allocations

### DIFF
--- a/doc/changelog.html
+++ b/doc/changelog.html
@@ -25,4 +25,5 @@
 <ul>
     <li>Fix: biome label under minimap compass now updates instantly instead of with up to ~1400ms delay. (Eldrinn-Elantey)</li>
     <li>Fix: replace internal sun.awt.image.IntegerComponentRaster with standard Java API in PixelPaint. (Eldrinn-Elantey)</li>
+    <li>Fix: reduce memory allocations during mapping. (Alexdoru)</li>
 </ul>

--- a/src/main/java/journeymap/client/cartography/ChunkPainter.java
+++ b/src/main/java/journeymap/client/cartography/ChunkPainter.java
@@ -7,9 +7,7 @@ package journeymap.client.cartography;
 
 import journeymap.common.Journeymap;
 
-import java.awt.AlphaComposite;
-import java.awt.Color;
-import java.awt.Graphics2D;
+import java.awt.*;
 import java.awt.image.BufferedImage;
 import java.awt.image.DataBufferInt;
 import java.util.concurrent.atomic.AtomicLong;
@@ -26,20 +24,16 @@ public class ChunkPainter
     public static final int COLOR_VOID = RGB.toInteger(17, 12, 25);
     protected static volatile AtomicLong badBlockCount = new AtomicLong(0);
 
-    private final int[][] colors = new int[16][16];
     private final Graphics2D g2D;
+    private final BufferedImage img;
+    private final int[] pixels;
 
     public ChunkPainter(Graphics2D g2D)
     {
         this.g2D = g2D;
-        for (int x = 0; x < 16; x++)
-        {
-            for (int z = 0; z < 16; z++)
-            {
-                colors[x][z] = Integer.MIN_VALUE;
-            }
-        }
         this.g2D.setComposite(ALPHA_OPAQUE);
+        this.img = new BufferedImage(16, 16, BufferedImage.TYPE_INT_ARGB);
+        this.pixels = ((DataBufferInt) img.getRaster().getDataBuffer()).getData();
     }
 
     /**
@@ -47,8 +41,8 @@ public class ChunkPainter
      */
     public void paintDimOverlay(int x, int z, float alpha)
     {
-        int color = colors[x][z];
-        if (color != Integer.MIN_VALUE)
+        final int color = pixels[z * 16 + x];
+        if (color != 0)
         {
             paintBlock(x, z, RGB.adjustBrightness(color, alpha));
         }
@@ -59,7 +53,7 @@ public class ChunkPainter
      */
     public void paintBlock(final int x, final int z, final int color)
     {
-        colors[x][z] = color;
+        pixels[z * 16 + x] = 0xFF000000 | color;
     }
 
     /**
@@ -99,19 +93,8 @@ public class ChunkPainter
     {
         try
         {
-            final BufferedImage img = new BufferedImage(16, 16, BufferedImage.TYPE_INT_ARGB);
-            final int[] data = ((DataBufferInt) img.getRaster().getDataBuffer()).getData();
-            for (int z = 0; z < 16; z++) {
-                for (int x = 0; x < 16; x++) {
-                    int c = colors[x][z];
-                    if (c != Integer.MIN_VALUE) {
-                        data[z * 16 + x] = 0xFF000000 | c;
-                    }
-                }
-            }
             g2D.drawImage(img, 0, 0, null);
-        }
-        finally
+        } finally
         {
             g2D.dispose();
         }

--- a/src/main/java/journeymap/client/cartography/ChunkPainter.java
+++ b/src/main/java/journeymap/client/cartography/ChunkPainter.java
@@ -10,6 +10,8 @@ import journeymap.common.Journeymap;
 import java.awt.AlphaComposite;
 import java.awt.Color;
 import java.awt.Graphics2D;
+import java.awt.image.BufferedImage;
+import java.awt.image.DataBufferInt;
 import java.util.concurrent.atomic.AtomicLong;
 
 /**
@@ -24,14 +26,20 @@ public class ChunkPainter
     public static final int COLOR_VOID = RGB.toInteger(17, 12, 25);
     protected static volatile AtomicLong badBlockCount = new AtomicLong(0);
 
-    int[][] colors = new int[16][16];
-    Graphics2D g2D;
+    private final int[][] colors = new int[16][16];
+    private final Graphics2D g2D;
 
     public ChunkPainter(Graphics2D g2D)
     {
         this.g2D = g2D;
-        initColorsArray();
-        g2D.setComposite(ALPHA_OPAQUE);
+        for (int x = 0; x < 16; x++)
+        {
+            for (int z = 0; z < 16; z++)
+            {
+                colors[x][z] = Integer.MIN_VALUE;
+            }
+        }
+        this.g2D.setComposite(ALPHA_OPAQUE);
     }
 
     /**
@@ -89,48 +97,24 @@ public class ChunkPainter
      */
     public void finishPainting()
     {
-        int color;
-        int lastColor = -1;
-
         try
         {
-            for (int z = 0; z < 16; z++)
-            {
-                for (int x = 0; x < 16; x++)
-                {
-                    color = colors[x][z];
-                    if (color == Integer.MIN_VALUE)
-                    {
-                        continue;
+            final BufferedImage img = new BufferedImage(16, 16, BufferedImage.TYPE_INT_ARGB);
+            final int[] data = ((DataBufferInt) img.getRaster().getDataBuffer()).getData();
+            for (int z = 0; z < 16; z++) {
+                for (int x = 0; x < 16; x++) {
+                    int c = colors[x][z];
+                    if (c != Integer.MIN_VALUE) {
+                        data[z * 16 + x] = 0xFF000000 | c;
                     }
-
-                    // Update color
-                    if (color != lastColor)
-                    {
-                        lastColor = color;
-                        g2D.setPaint(RGB.paintOf(color));
-                    }
-
-                    g2D.fillRect(x, z, 1, 1);
                 }
             }
+            g2D.drawImage(img, 0, 0, null);
         }
         finally
         {
             g2D.dispose();
-            g2D = null;
-            colors = null;
         }
     }
 
-    public void initColorsArray()
-    {
-        for (int x = 0; x < 16; x++)
-        {
-            for (int z = 0; z < 16; z++)
-            {
-                colors[x][z] = Integer.MIN_VALUE;
-            }
-        }
-    }
 }

--- a/src/main/java/journeymap/client/cartography/ChunkPainter.java
+++ b/src/main/java/journeymap/client/cartography/ChunkPainter.java
@@ -10,6 +10,7 @@ import journeymap.common.Journeymap;
 import java.awt.*;
 import java.awt.image.BufferedImage;
 import java.awt.image.DataBufferInt;
+import java.util.Arrays;
 import java.util.concurrent.atomic.AtomicLong;
 
 /**
@@ -28,12 +29,13 @@ public class ChunkPainter
     private final BufferedImage img;
     private final int[] pixels;
 
-    public ChunkPainter(Graphics2D g2D)
+    public ChunkPainter(BufferedImage buffer, Graphics2D g2D)
     {
         this.g2D = g2D;
         this.g2D.setComposite(ALPHA_OPAQUE);
-        this.img = new BufferedImage(16, 16, BufferedImage.TYPE_INT_ARGB);
+        this.img = buffer;
         this.pixels = ((DataBufferInt) img.getRaster().getDataBuffer()).getData();
+        Arrays.fill(this.pixels, 0);
     }
 
     /**

--- a/src/main/java/journeymap/client/cartography/ChunkPainter.java
+++ b/src/main/java/journeymap/client/cartography/ChunkPainter.java
@@ -7,7 +7,9 @@ package journeymap.client.cartography;
 
 import journeymap.common.Journeymap;
 
-import java.awt.*;
+import java.awt.AlphaComposite;
+import java.awt.Color;
+import java.awt.Graphics2D;
 import java.awt.image.BufferedImage;
 import java.awt.image.DataBufferInt;
 import java.util.Arrays;

--- a/src/main/java/journeymap/client/cartography/ChunkRenderController.java
+++ b/src/main/java/journeymap/client/cartography/ChunkRenderController.java
@@ -29,6 +29,9 @@ public class ChunkRenderController
     private final IChunkRenderer endRenderer;
     private final SurfaceRenderer overWorldSurfaceRenderer;
     private final IChunkRenderer overWorldCaveRenderer;
+    private final BufferedImage reusableBuffer1;
+    private final BufferedImage reusableBuffer2;
+    private final BufferedImage reusableBuffer3;
 
     public ChunkRenderController()
     {
@@ -38,6 +41,9 @@ public class ChunkRenderController
         overWorldSurfaceRenderer = surfaceRenderer;
         overWorldCaveRenderer = new CaveRenderer(surfaceRenderer);
         //standardRenderer = new ChunkTopoRenderer();
+        reusableBuffer1 = new BufferedImage(16, 16, BufferedImage.TYPE_INT_ARGB);
+        reusableBuffer2 = new BufferedImage(16, 16, BufferedImage.TYPE_INT_ARGB);
+        reusableBuffer3 = new BufferedImage(16, 16, BufferedImage.TYPE_INT_ARGB);
     }
 
     public boolean renderChunk(RegionCoord rCoord, MapType mapType, ChunkMD chunkMd)
@@ -60,7 +66,7 @@ public class ChunkRenderController
                 BufferedImage image = regionImageSet.getChunkImage(chunkMd, mapType);
                 if (image != null)
                 {
-                    undergroundG2D = new ChunkPainter(RegionImageHandler.initRenderingHints(image.createGraphics()));
+                    undergroundG2D = new ChunkPainter(reusableBuffer1, RegionImageHandler.initRenderingHints(image.createGraphics()));
                     switch (rCoord.dimension)
                     {
                         case -1:
@@ -92,12 +98,12 @@ public class ChunkRenderController
 
                 if (imageDay != null)
                 {
-                    dayG2D = new ChunkPainter(RegionImageHandler.initRenderingHints(imageDay.createGraphics()));
+                    dayG2D = new ChunkPainter(reusableBuffer2, RegionImageHandler.initRenderingHints(imageDay.createGraphics()));
                 }
 
                 if (imageNight != null)
                 {
-                    nightG2D = new ChunkPainter(RegionImageHandler.initRenderingHints(imageNight.createGraphics()));
+                    nightG2D = new ChunkPainter(reusableBuffer3, RegionImageHandler.initRenderingHints(imageNight.createGraphics()));
                 }
 
                 renderOkay = dayG2D != null && overWorldSurfaceRenderer.render(dayG2D, nightG2D, chunkMd);

--- a/src/main/java/journeymap/client/cartography/IChunkRenderer.java
+++ b/src/main/java/journeymap/client/cartography/IChunkRenderer.java
@@ -13,6 +13,6 @@ public interface IChunkRenderer
 
     public void setStratumColors(Stratum stratum, int lightAttenuation, Integer waterColor, boolean waterAbove, boolean underground, boolean mapCaveLighting);
 
-    public float[] getAmbientColor();
+    public int getAmbientColor();
 
 }

--- a/src/main/java/journeymap/client/cartography/RGB.java
+++ b/src/main/java/journeymap/client/cartography/RGB.java
@@ -93,6 +93,7 @@ public final class RGB
                 (((int) (b * 255 + 0.5) & 0xFF));
     }
 
+    @Deprecated // don't use arrays for colors
     public static int toInteger(float[] rgb)
     {
         return ((0xFF) << 24) |
@@ -109,6 +110,7 @@ public final class RGB
                 ((b & 0xFF));
     }
 
+    @Deprecated // don't use arrays for colors
     public static int toInteger(int[] rgb)
     {
         return ((0xFF) << 24) |
@@ -128,14 +130,12 @@ public final class RGB
         {
             return "null";
         }
-        int[] ints = ints(rgb);
-        return String.format("r=%s,g=%s,b=%s", ints[0], ints[1], ints[2]);
+        return String.format("r=%s,g=%s,b=%s", (rgb >> 16) & 0xFF, (rgb >> 8) & 0xFF, (rgb) & 0xFF);
     }
 
     public static String toHexString(Integer rgb)
     {
-        int[] ints = ints(rgb);
-        return String.format("#%02x%02x%02x", ints[0], ints[1], ints[2]);
+        return String.format("#%02x%02x%02x", (rgb >> 16) & 0xFF, (rgb >> 8) & 0xFF, (rgb) & 0xFF);
     }
 
     /**
@@ -147,7 +147,14 @@ public final class RGB
         {
             return rgb;
         }
-        return toInteger(clampFloats(floats(rgb), factor));
+        final float r = ((rgb >> 16) & 0xFF) / 255f;
+        final float g = ((rgb >> 8) & 0xFF) / 255f;
+        final float b = ((rgb) & 0xFF) / 255f;
+        return toInteger(
+                clampFloat(r * factor),
+                clampFloat(g * factor),
+                clampFloat(b * factor)
+        );
     }
 
     /**
@@ -155,8 +162,10 @@ public final class RGB
      */
     public static int greyScale(int rgb)
     {
-        int[] ints = ints(rgb);
-        int avg = clampInt((ints[0] + ints[1] + ints[2]) / 3);
+        final int r = (rgb >> 16) & 0xFF;
+        final int g = (rgb >> 8) & 0xFF;
+        final int b = (rgb) & 0xFF;
+        int avg = clampInt(r + g + b / 3);
         return toInteger(avg, avg, avg);
     }
 
@@ -167,11 +176,14 @@ public final class RGB
     public static int bevelSlope(int rgb, float factor)
     {
         final float bluer = (factor < 1) ? .85f : 1f;
-        float[] floats = floats(rgb);
-        floats[0] = floats[0] * bluer * factor;
-        floats[1] = floats[1] * bluer * factor;
-        floats[2] = floats[2] * factor;
-        return toInteger(clampFloats(floats, 1f));
+        final float r = ((rgb >> 16) & 0xFF) / 255f;
+        final float g = ((rgb >> 8) & 0xFF) / 255f;
+        final float b = ((rgb) & 0xFF) / 255f;
+        return toInteger(
+                clampFloat(r * bluer * factor),
+                clampFloat(g * bluer * factor),
+                clampFloat(b * factor)
+        );
     }
 
     /**
@@ -179,18 +191,23 @@ public final class RGB
      */
     public static int darkenAmbient(int rgb, float factor, float[] ambient)
     {
-        float[] floats = floats(rgb);
-        floats[0] = floats[0] * (factor + ambient[0]);
-        floats[1] = floats[1] * (factor + ambient[1]);
-        floats[2] = floats[2] * (factor + ambient[2]);
-        return toInteger(clampFloats(floats, 1f));
+        final float r = ((rgb >> 16) & 0xFF) / 255f;
+        final float g = ((rgb >> 8) & 0xFF) / 255f;
+        final float b = ((rgb) & 0xFF) / 255f;
+        return toInteger(
+                clampFloat(r * (factor + ambient[0])),
+                clampFloat(g * (factor + ambient[1])),
+                clampFloat(b * (factor + ambient[2]))
+        );
     }
 
     /**
      * Creates an array with three elements [r,g,b]
+     *
      * @param rgb color integer
      * @return array
      */
+    @Deprecated // don't use arrays for colors
     public static int[] ints(int rgb)
     {
         return new int[]{(rgb >> 16) & 0xFF, (rgb >> 8) & 0xFF, (rgb) & 0xFF};
@@ -198,15 +215,18 @@ public final class RGB
 
     /**
      * Creates an array with four elements [r,g,b,a]
-     * @param rgb color integer
+     *
+     * @param rgb   color integer
      * @param alpha alpha (0-255)
      * @return array
      */
+    @Deprecated // don't use arrays for colors
     public static int[] ints(int rgb, int alpha)
     {
         return new int[]{(rgb >> 16) & 0xFF, (rgb >> 8) & 0xFF, (rgb) & 0xFF, alpha & 0xFF};
     }
 
+    @Deprecated // don't use arrays for colors
     public static float[] floats(int rgb)
     {
         return new float[]{((rgb >> 16) & 0xFF) / 255f, ((rgb >> 8) & 0xFF) / 255f, ((rgb) & 0xFF) / 255f};
@@ -226,14 +246,18 @@ public final class RGB
             return rgb;
         }
 
-        float[] floats = floats(rgb);
-        float[] otherFloats = floats(otherRgb);
+        final float r = ((rgb >> 16) & 0xFF) / 255f;
+        final float g = ((rgb >> 8) & 0xFF) / 255f;
+        final float b = ((rgb) & 0xFF) / 255f;
+        final float or = ((otherRgb >> 16) & 0xFF) / 255f;
+        final float og = ((otherRgb >> 8) & 0xFF) / 255f;
+        final float ob = ((otherRgb) & 0xFF) / 255f;
 
-        floats[0] = otherFloats[0] * otherAlpha / 1f + floats[0] * (1 - otherAlpha);
-        floats[1] = otherFloats[1] * otherAlpha / 1f + floats[1] * (1 - otherAlpha);
-        floats[2] = otherFloats[2] * otherAlpha / 1f + floats[2] * (1 - otherAlpha);
-
-        return toInteger(floats);
+        return toInteger(
+                or * otherAlpha + r * (1 - otherAlpha),
+                og * otherAlpha + g * (1 - otherAlpha),
+                ob * otherAlpha + b * (1 - otherAlpha)
+        );
     }
 
     /**
@@ -245,14 +269,33 @@ public final class RGB
      */
     public static int multiply(int rgb, int multiplier)
     {
-        float[] rgbFloats = floats(rgb);
-        float[] multFloats = floats(multiplier);
+        final float r = ((rgb >> 16) & 0xFF) / 255f;
+        final float g = ((rgb >> 8) & 0xFF) / 255f;
+        final float b = ((rgb) & 0xFF) / 255f;
+        final float mr = ((multiplier >> 16) & 0xFF) / 255f;
+        final float mg = ((multiplier >> 8) & 0xFF) / 255f;
+        final float mb = ((multiplier) & 0xFF) / 255f;
+        return toInteger(
+                r * mr,
+                g * mg,
+                b * mb
+        );
+    }
 
-        rgbFloats[0] = rgbFloats[0] * multFloats[0];
-        rgbFloats[1] = rgbFloats[1] * multFloats[1];
-        rgbFloats[2] = rgbFloats[2] * multFloats[2];
+    /**
+     * Returns an rgb array of floats clamped between 0 and 1 after a factor is applied.
+     */
+    @Deprecated // don't use arrays for colors
+    public static float[] clampFloats(float[] rgbFloats, float factor)
+    {
+        float r = rgbFloats[0] * factor;
+        float g = rgbFloats[1] * factor;
+        float b = rgbFloats[2] * factor;
+        rgbFloats[0] = clampFloat(r);
+        rgbFloats[1] = clampFloat(g);
+        rgbFloats[2] = clampFloat(b);
 
-        return toInteger(rgbFloats);
+        return rgbFloats;
     }
 
     /**
@@ -263,22 +306,7 @@ public final class RGB
      */
     public static float clampFloat(float value)
     {
-        return value < 0f ? 0f : (value > 1f ? 1f : value);
-    }
-
-    /**
-     * Returns an rgb array of floats clamped between 0 and 1 after a factor is applied.
-     */
-    public static float[] clampFloats(float[] rgbFloats, float factor)
-    {
-        float r = rgbFloats[0] * factor;
-        float g = rgbFloats[1] * factor;
-        float b = rgbFloats[2] * factor;
-        rgbFloats[0] = r < 0f ? 0f : (r > 1f ? 1f : r);
-        rgbFloats[1] = g < 0f ? 0f : (g > 1f ? 1f : g);
-        rgbFloats[2] = b < 0f ? 0f : (b > 1f ? 1f : b);
-
-        return rgbFloats;
+        return value < 0f ? 0f : value > 1f ? 1f : value;
     }
 
     /**
@@ -289,7 +317,7 @@ public final class RGB
      */
     public static int clampInt(int value)
     {
-        return value < 0 ? 0 : (value > 255 ? 255 : value);
+        return value < 0 ? 0 : value > 255 ? 255 : value;
     }
 
 }

--- a/src/main/java/journeymap/client/cartography/RGB.java
+++ b/src/main/java/journeymap/client/cartography/RGB.java
@@ -110,6 +110,11 @@ public final class RGB
                 ((b & 0xFF));
     }
 
+    public static int toRGBA(int rgb, int alpha)
+    {
+        return rgb << 8 | (alpha & 0xFF);
+    }
+
     @Deprecated // don't use arrays for colors
     public static int toInteger(int[] rgb)
     {
@@ -189,6 +194,7 @@ public final class RGB
     /**
      * Darken a color by a factor, add a fog tint.
      */
+    @Deprecated // don't use arrays for colors
     public static int darkenAmbient(int rgb, float factor, float[] ambient)
     {
         final float r = ((rgb >> 16) & 0xFF) / 255f;
@@ -200,6 +206,25 @@ public final class RGB
                 clampFloat(b * (factor + ambient[2]))
         );
     }
+
+    /**
+     * Darken a color by a factor, add a fog tint.
+     */
+    public static int darkenAmbient(int rgb, float factor, int ambient)
+    {
+        final float r = ((rgb >> 16) & 0xFF) / 255f;
+        final float g = ((rgb >> 8) & 0xFF) / 255f;
+        final float b = ((rgb) & 0xFF) / 255f;
+        final float ar = ((ambient >> 16) & 0xFF) / 255f;
+        final float ag = ((ambient >> 8) & 0xFF) / 255f;
+        final float ab = ((ambient) & 0xFF) / 255f;
+        return toInteger(
+                clampFloat(r * (factor + ar)),
+                clampFloat(g * (factor + ag)),
+                clampFloat(b * (factor + ab))
+        );
+    }
+
 
     /**
      * Creates an array with three elements [r,g,b]

--- a/src/main/java/journeymap/client/cartography/RGB.java
+++ b/src/main/java/journeymap/client/cartography/RGB.java
@@ -93,7 +93,10 @@ public final class RGB
                 (((int) (b * 255 + 0.5) & 0xFF));
     }
 
-    @Deprecated // don't use arrays for colors
+    /**
+     * @deprecated don't use arrays for colors
+     */
+    @Deprecated
     public static int toInteger(float[] rgb)
     {
         return ((0xFF) << 24) |
@@ -115,7 +118,10 @@ public final class RGB
         return rgb << 8 | (alpha & 0xFF);
     }
 
-    @Deprecated // don't use arrays for colors
+    /**
+     * @deprecated don't use arrays for colors
+     */
+    @Deprecated
     public static int toInteger(int[] rgb)
     {
         return ((0xFF) << 24) |
@@ -193,8 +199,9 @@ public final class RGB
 
     /**
      * Darken a color by a factor, add a fog tint.
+     * @deprecated don't use arrays for colors
      */
-    @Deprecated // don't use arrays for colors
+    @Deprecated
     public static int darkenAmbient(int rgb, float factor, float[] ambient)
     {
         final float r = ((rgb >> 16) & 0xFF) / 255f;
@@ -231,8 +238,9 @@ public final class RGB
      *
      * @param rgb color integer
      * @return array
+     * @deprecated don't use arrays for colors
      */
-    @Deprecated // don't use arrays for colors
+    @Deprecated
     public static int[] ints(int rgb)
     {
         return new int[]{(rgb >> 16) & 0xFF, (rgb >> 8) & 0xFF, (rgb) & 0xFF};
@@ -244,14 +252,18 @@ public final class RGB
      * @param rgb   color integer
      * @param alpha alpha (0-255)
      * @return array
+     * @deprecated don't use arrays for colors
      */
-    @Deprecated // don't use arrays for colors
+    @Deprecated
     public static int[] ints(int rgb, int alpha)
     {
         return new int[]{(rgb >> 16) & 0xFF, (rgb >> 8) & 0xFF, (rgb) & 0xFF, alpha & 0xFF};
     }
 
-    @Deprecated // don't use arrays for colors
+    /**
+     * @deprecated don't use arrays for colors
+     */
+    @Deprecated
     public static float[] floats(int rgb)
     {
         return new float[]{((rgb >> 16) & 0xFF) / 255f, ((rgb >> 8) & 0xFF) / 255f, ((rgb) & 0xFF) / 255f};
@@ -309,8 +321,9 @@ public final class RGB
 
     /**
      * Returns an rgb array of floats clamped between 0 and 1 after a factor is applied.
+     * @deprecated don't use arrays for colors
      */
-    @Deprecated // don't use arrays for colors
+    @Deprecated
     public static float[] clampFloats(float[] rgbFloats, float factor)
     {
         float r = rgbFloats[0] * factor;

--- a/src/main/java/journeymap/client/cartography/RGB.java
+++ b/src/main/java/journeymap/client/cartography/RGB.java
@@ -170,7 +170,7 @@ public final class RGB
         final int r = (rgb >> 16) & 0xFF;
         final int g = (rgb >> 8) & 0xFF;
         final int b = (rgb) & 0xFF;
-        int avg = clampInt(r + g + b / 3);
+        int avg = clampInt((r + g + b) / 3);
         return toInteger(avg, avg, avg);
     }
 

--- a/src/main/java/journeymap/client/cartography/render/BaseRenderer.java
+++ b/src/main/java/journeymap/client/cartography/render/BaseRenderer.java
@@ -40,7 +40,7 @@ public abstract class BaseRenderer implements IChunkRenderer, RemovalListener<Ch
     protected static final AlphaComposite ALPHA_OPAQUE = AlphaComposite.getInstance(AlphaComposite.SRC_OVER, 1F);
     protected static final int COLOR_BLACK = Color.black.getRGB();
     protected static final int COLOR_VOID = RGB.toInteger(17, 12, 25);
-    protected static final float[] DEFAULT_FOG = new float[]{0, 0, .1f};
+    protected static final int DEFAULT_FOG = RGB.toInteger(0, 0, .1f);
     protected final DataCache dataCache = DataCache.instance();
     protected CoreProperties coreProperties;
     protected BlockColumnPropertiesCache columnPropertiesCache = null;
@@ -52,7 +52,7 @@ public abstract class BaseRenderer implements IChunkRenderer, RemovalListener<Ch
     protected boolean mapCrops;
     protected boolean mapPlants;
     protected boolean mapPlantShadows;
-    protected float[] ambientColor;
+    protected int ambientColor;
 
 
     protected ArrayList<BlockCoordIntPair> primarySlopeOffsets = new ArrayList<BlockCoordIntPair>(3);
@@ -130,11 +130,11 @@ public abstract class BaseRenderer implements IChunkRenderer, RemovalListener<Ch
         mapCrops = coreProperties.mapCrops.get();
 
         // Subclasses should override
-        this.ambientColor = new float[]{0, 0, 0};
+        this.ambientColor = 0;
     }
 
     @Override
-    public float[] getAmbientColor()
+    public int getAmbientColor()
     {
         return DEFAULT_FOG;
     }

--- a/src/main/java/journeymap/client/cartography/render/EndRenderer.java
+++ b/src/main/java/journeymap/client/cartography/render/EndRenderer.java
@@ -31,7 +31,7 @@ public class EndRenderer extends SurfaceRenderer implements IChunkRenderer
     protected void updateOptions()
     {
         super.updateOptions();
-        this.ambientColor = RGB.floats(tweakEndAmbientColor);
+        this.ambientColor = tweakEndAmbientColor;
         this.tweakMoonlightLevel = 5f;
     }
 

--- a/src/main/java/journeymap/client/cartography/render/NetherRenderer.java
+++ b/src/main/java/journeymap/client/cartography/render/NetherRenderer.java
@@ -31,7 +31,7 @@ public class NetherRenderer extends CaveRenderer implements IChunkRenderer
     protected void updateOptions()
     {
         super.updateOptions();
-        this.ambientColor = RGB.floats(tweakNetherAmbientColor);
+        this.ambientColor = tweakNetherAmbientColor;
         this.mapSurfaceAboveCaves = false;
     }
 
@@ -134,7 +134,7 @@ public class NetherRenderer extends CaveRenderer implements IChunkRenderer
     }
 
     @Override
-    public float[] getAmbientColor()
+    public int getAmbientColor()
     {
         return ambientColor;
     }

--- a/src/main/java/journeymap/client/cartography/render/SurfaceRenderer.java
+++ b/src/main/java/journeymap/client/cartography/render/SurfaceRenderer.java
@@ -45,7 +45,7 @@ public class SurfaceRenderer extends BaseRenderer implements IChunkRenderer
     protected void updateOptions()
     {
         super.updateOptions();
-        this.ambientColor = RGB.floats(tweakSurfaceAmbientColor);
+        this.ambientColor = tweakSurfaceAmbientColor;
     }
 
     /**

--- a/src/main/java/journeymap/client/forge/helper/IRenderHelper.java
+++ b/src/main/java/journeymap/client/forge/helper/IRenderHelper.java
@@ -19,7 +19,10 @@ public interface IRenderHelper
 
     public void addVertexWithUV(double x, double y, double z, double u, double v);
 
+    @Deprecated // don't use arrays for colors
     public void addVertexWithUV(double x, double y, double z, double u, double v, int[] rgba);
+
+    public void addVertexWithUV(double x, double y, double z, double u, double v, int rgba);
 
     public void draw();
 

--- a/src/main/java/journeymap/client/forge/helper/IRenderHelper.java
+++ b/src/main/java/journeymap/client/forge/helper/IRenderHelper.java
@@ -19,7 +19,10 @@ public interface IRenderHelper
 
     public void addVertexWithUV(double x, double y, double z, double u, double v);
 
-    @Deprecated // don't use arrays for colors
+    /**
+     * @deprecated don't use arrays for colors
+     */
+    @Deprecated
     public void addVertexWithUV(double x, double y, double z, double u, double v, int[] rgba);
 
     public void addVertexWithUV(double x, double y, double z, double u, double v, int rgba);

--- a/src/main/java/journeymap/client/forge/helper/impl/RenderHelper_1_7_10.java
+++ b/src/main/java/journeymap/client/forge/helper/impl/RenderHelper_1_7_10.java
@@ -5,13 +5,9 @@
 
 package journeymap.client.forge.helper.impl;
 
-import journeymap.client.cartography.RGB;
 import journeymap.client.forge.helper.IRenderHelper;
-import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.OpenGlHelper;
-import net.minecraft.client.renderer.RenderGlobal;
 import net.minecraft.client.renderer.Tessellator;
-import net.minecraft.client.renderer.WorldRenderer;
 import org.lwjgl.opengl.GL11;
 
 import java.awt.*;
@@ -89,6 +85,25 @@ public class RenderHelper_1_7_10 implements IRenderHelper
     {
         // 1.7
         tessellator.setColorRGBA(rgba[0], rgba[1], rgba[2], rgba[3]);
+        tessellator.addVertexWithUV(x, y, z, u, v);
+
+        // 1.8
+        // tessellator.setColorRGBA(rgba[0], rgba[1], rgba[2], rgba[3]);
+        // worldrenderer.addVertexWithUV(x, y, z, u, v);
+
+        // 1.8.8
+        // worldrenderer.pos(x, y, z).tex(u, v).color(rgba[0], rgba[1], rgba[2], rgba[3]).endVertex();
+    }
+
+    @Override
+    public void addVertexWithUV(double x, double y, double z, double u, double v, int rgba)
+    {
+        // 1.7
+        final int r = (rgba >> 24) & 0xFF;
+        final int g = (rgba >> 16) & 0xFF;
+        final int b = (rgba >> 8) & 0xFF;
+        final int a = (rgba) & 0xFF;
+        tessellator.setColorRGBA(r, g, b, a);
         tessellator.addVertexWithUV(x, y, z, u, v);
 
         // 1.8

--- a/src/main/java/journeymap/client/io/MapSaver.java
+++ b/src/main/java/journeymap/client/io/MapSaver.java
@@ -171,8 +171,8 @@ public class MapSaver
                 Matcher matcher = tilePattern.matcher(file.getName());
                 if (matcher.matches())
                 {
-                    Integer x = Integer.parseInt(matcher.group(1));
-                    Integer z = Integer.parseInt(matcher.group(2));
+                    int x = Integer.parseInt(matcher.group(1));
+                    int z = Integer.parseInt(matcher.group(2));
                     if (minX == null || x < minX)
                     {
                         minX = x;

--- a/src/main/java/journeymap/client/model/EntityHelper.java
+++ b/src/main/java/journeymap/client/model/EntityHelper.java
@@ -272,8 +272,8 @@ public class EntityHelper
         public int compare(EntityDTO o1, EntityDTO o2)
         {
 
-            Integer o1rank = 0;
-            Integer o2rank = 0;
+            int o1rank = 0;
+            int o2rank = 0;
 
             if (o1.customName != null)
             {
@@ -299,7 +299,7 @@ public class EntityHelper
                 }
             }
 
-            return o1rank.compareTo(o2rank);
+            return Integer.compare(o1rank, o2rank);
         }
 
     }

--- a/src/main/java/journeymap/client/model/GridSpec.java
+++ b/src/main/java/journeymap/client/model/GridSpec.java
@@ -33,10 +33,10 @@ public class GridSpec
     public GridSpec(Style style, Color color, float alpha)
     {
         this.style = style;
-        float[] rgb = RGB.floats(color.getRGB());
-        this.red = rgb[0];
-        this.green = rgb[1];
-        this.blue = rgb[2];
+        final int rgb = color.getRGB();
+        this.red = ((rgb >> 16) & 0xFF) / 255f;
+        this.green = ((rgb >> 8) & 0xFF) / 255f;
+        this.blue = ((rgb) & 0xFF) / 255f;
         if (alpha < 0)
         {
             alpha = 0f;
@@ -99,7 +99,7 @@ public class GridSpec
         renderHelper.glClearColor(1, 1, 1, 1f); // defensive against shaders
     }
 
-    public Integer getColor()
+    public int getColor()
     {
         return RGB.toInteger(red, green, blue);
     }

--- a/src/main/java/journeymap/client/model/Waypoint.java
+++ b/src/main/java/journeymap/client/model/Waypoint.java
@@ -235,20 +235,19 @@ public class Waypoint implements Serializable
         setColor(RGB.toInteger(r, g, b));
     }
 
-    public Integer getColor()
+    public int getColor()
     {
         return RGB.toInteger(r, g, b);
     }
 
-    public void setColor(Integer color)
+    public void setColor(int rgb)
     {
-        int c[] = RGB.ints(color);
-        this.r = c[0];
-        this.g = c[1];
-        this.b = c[2];
+        this.r = (rgb >> 16) & 0xFF;
+        this.g = (rgb >> 8) & 0xFF;
+        this.b = (rgb) & 0xFF;
     }
 
-    public Integer getSafeColor()
+    public int getSafeColor()
     {
         if (r + g + b >= 100)
         {

--- a/src/main/java/journeymap/client/model/mod/vanilla/VanillaColorHandler.java
+++ b/src/main/java/journeymap/client/model/mod/vanilla/VanillaColorHandler.java
@@ -106,7 +106,7 @@ public class VanillaColorHandler implements ModBlockDelegate.IModBlockColorHandl
      */
     protected Integer getCustomBiomeColor(ChunkMD chunkMD, BlockMD blockMD, int globalX, int y, int globalZ)
     {
-        Integer color = getBaseColor(chunkMD, blockMD, globalX, y, globalZ);
+        int color = getBaseColor(chunkMD, blockMD, globalX, y, globalZ);
         int tint = getTint(chunkMD, blockMD, globalX, y, globalZ);
 
         if (!RGB.isWhite(tint) && !RGB.isBlack(tint))

--- a/src/main/java/journeymap/client/render/draw/DrawUtil.java
+++ b/src/main/java/journeymap/client/render/draw/DrawUtil.java
@@ -269,8 +269,12 @@ public class DrawUtil
 
             if (blend && color != null)
             {
-                float[] c = RGB.floats(color);
-                renderHelper.glColor4f(c[0], c[1], c[2], alpha);
+                renderHelper.glColor4f(
+                        ((color >> 16) & 0xFF) / 255f,
+                        ((color >> 8) & 0xFF) / 255f,
+                        ((color) & 0xFF) / 255f,
+                        alpha
+                );
             }
             else
             {
@@ -334,7 +338,7 @@ public class DrawUtil
         renderHelper.glBlendFunc(GL11.GL_SRC_ALPHA, GL11.GL_ONE_MINUS_SRC_ALPHA, 1, 0);
 
         // Draw
-        int[] rgba = RGB.ints(color, alpha);
+        int rgba = RGB.toRGBA(color, alpha);
         renderHelper.startDrawingQuads(true);
         renderHelper.addVertexWithUV(x, height + y, zLevel, 0, 1, rgba);
         renderHelper.addVertexWithUV(x + width, height + y, zLevel, 1, 1, rgba);
@@ -355,8 +359,8 @@ public class DrawUtil
      */
     public static void drawGradientRect(double x, double y, double width, double height, Integer startColor, int startAlpha, Integer endColor, int endAlpha)
     {
-        int[] rgbaStart = RGB.ints(startColor, startAlpha);
-        int[] rgbaEnd = RGB.ints(endColor, endAlpha);
+        int rgbaStart = RGB.toRGBA(startColor, startAlpha);
+        int rgbaEnd = RGB.toRGBA(endColor, endAlpha);
 
         renderHelper.glDisableTexture2D();
         renderHelper.glEnableBlend();

--- a/src/main/java/journeymap/client/render/ingame/RenderWaypointBeacon.java
+++ b/src/main/java/journeymap/client/render/ingame/RenderWaypointBeacon.java
@@ -358,7 +358,7 @@ public class RenderWaypointBeacon
             double d3 = (double) time * 0.025D * (1.0D - (double) (b0 & 1) * 2.5D);
             //double d3 = (double) time * 0.025D * -1.5D;
 
-            int[] rgba = RGB.ints(color, clampAlpha(Math.round(115.0F * alphaMultiplier)));
+            int rgba = RGB.toRGBA(color, clampAlpha(Math.round(115.0F * alphaMultiplier)));
             renderHelper.startDrawingQuads(true);
             renderHelper.glEnableBlend();
 
@@ -371,10 +371,10 @@ public class RenderWaypointBeacon
             double d10 = Math.sin(d3 + 3.9269908169872414D) * d4;
             double d11 = Math.cos(d3 + 5.497787143782138D) * d4;
             double d12 = Math.sin(d3 + 5.497787143782138D) * d4;
-            double d13 = (double) (256.0F * f1);
+            double d13 = 256.0F * f1;
             double d14 = 0.0D;
             double d15 = 1.0D;
-            double d16 = (double) (-1.0F + texOffset);
+            double d16 = -1.0F + texOffset;
             double d17 = (double) (256.0F * f1) * (0.5D / d4) + d16;
             renderHelper.addVertexWithUV(x + d5, y + d13, z + d6, d15, d17, rgba);
             renderHelper.addVertexWithUV(x + d5, y, z + d6, d15, d16, rgba);
@@ -410,7 +410,7 @@ public class RenderWaypointBeacon
             renderHelper.glBlendFunc(770, 771, 1, 0);
             renderHelper.glDepthMask(false);
 
-            int[] rgba = RGB.ints(color, clampAlpha(Math.round(40.0F * alphaMultiplier)));
+            int rgba = RGB.toRGBA(color, clampAlpha(Math.round(40.0F * alphaMultiplier)));
             renderHelper.startDrawingQuads(true);
             
             renderHelper.addVertexWithUV(x + .2, y + d26, z + .2, 1, d30, rgba);

--- a/src/main/java/journeymap/client/render/map/TileDrawStep.java
+++ b/src/main/java/journeymap/client/render/map/TileDrawStep.java
@@ -95,7 +95,7 @@ public class TileDrawStep
         }
 
         //boolean scaledUpdatePending = !regionUpdatePending && highQuality && updateScaledTexture();
-        Integer textureId = -1;
+        int textureId = -1;
         boolean useScaled = false;
 
         if (highQuality && scaledTexture != null)

--- a/src/main/java/journeymap/client/render/texture/TextureImpl.java
+++ b/src/main/java/journeymap/client/render/texture/TextureImpl.java
@@ -15,7 +15,9 @@ import net.minecraft.client.resources.IResourceManager;
 import org.lwjgl.opengl.GL11;
 
 import java.awt.image.BufferedImage;
+import java.awt.image.DataBufferInt;
 import java.nio.ByteBuffer;
+import java.util.Arrays;
 import java.util.concurrent.locks.ReentrantLock;
 
 public class TextureImpl extends AbstractTexture
@@ -80,6 +82,8 @@ public class TextureImpl extends AbstractTexture
         }
     }
 
+    private int[] pixelBuffer;
+
     /**
      * Can be safely called without the OpenGL Context.
      */
@@ -102,22 +106,40 @@ public class TextureImpl extends AbstractTexture
 
             this.width = bufferedImage.getWidth();
             this.height = bufferedImage.getHeight();
-            int bufferSize = width * height * 4; // RGBA
+            final int pixelAmount = width * height;
+            final int bufferSize = pixelAmount * 4; // RGBA
 
-            if (buffer == null || (buffer.capacity() != bufferSize))
+            if (buffer == null || buffer.capacity() != bufferSize)
             {
                 buffer = ByteBuffer.allocateDirect(bufferSize);
             }
             buffer.clear();
 
-            int[] pixels = new int[width * height];
-            bufferedImage.getRGB(0, 0, width, height, pixels, 0, width);
-            int pixel;
+            final int[] pixels;
+
+            if (bufferedImage.getRaster().getDataBuffer() instanceof DataBufferInt)
+            {
+                pixels = ((DataBufferInt) bufferedImage.getRaster().getDataBuffer()).getData();
+            }
+            else
+            {
+                if (pixelBuffer == null || pixelBuffer.length != pixelAmount)
+                {
+                    pixelBuffer = new int[pixelAmount];
+                }
+                else
+                {
+                    Arrays.fill(pixelBuffer, 0);
+                }
+
+                pixels = bufferedImage.getRGB(0, 0, width, height, pixelBuffer, 0, width);
+            }
+
             for (int y = 0; y < height; y++)
             {
                 for (int x = 0; x < width; x++)
                 {
-                    pixel = pixels[y * width + x];
+                    final int pixel = pixels[y * width + x];
                     buffer.put((byte) ((pixel >> 16) & 0xFF));     // Red
                     buffer.put((byte) ((pixel >> 8) & 0xFF));      // Green
                     buffer.put((byte) ((pixel & 0xFF)));           // Blue

--- a/src/main/java/journeymap/client/render/texture/TextureImpl.java
+++ b/src/main/java/journeymap/client/render/texture/TextureImpl.java
@@ -135,14 +135,12 @@ public class TextureImpl extends AbstractTexture
                 pixels = bufferedImage.getRGB(0, 0, width, height, pixelBuffer, 0, width);
             }
 
-            for (int y = 0; y < height; y++)
+            final ByteBuffer buff = buffer;
+            for (int i = 0; i < pixelAmount; i++)
             {
-                for (int x = 0; x < width; x++)
-                {
-                    final int argb = pixels[y * width + x];
-                    final int rgba = (argb << 8) | ((argb >> 24) & 0xFF);
-                    buffer.putInt(rgba);
-                }
+                final int argb = pixels[i];
+                final int rgba = (argb << 8) | ((argb >> 24) & 0xFF);
+                buff.putInt(rgba);
             }
             buffer.flip();
             buffer.rewind();

--- a/src/main/java/journeymap/client/render/texture/TextureImpl.java
+++ b/src/main/java/journeymap/client/render/texture/TextureImpl.java
@@ -139,11 +139,9 @@ public class TextureImpl extends AbstractTexture
             {
                 for (int x = 0; x < width; x++)
                 {
-                    final int pixel = pixels[y * width + x];
-                    buffer.put((byte) ((pixel >> 16) & 0xFF));     // Red
-                    buffer.put((byte) ((pixel >> 8) & 0xFF));      // Green
-                    buffer.put((byte) ((pixel & 0xFF)));           // Blue
-                    buffer.put((byte) ((pixel >> 24) & 0xFF));     // Alpha
+                    final int argb = pixels[y * width + x];
+                    final int rgba = (argb << 8) | ((argb >> 24) & 0xFF);
+                    buffer.putInt(rgba);
                 }
             }
             buffer.flip();

--- a/src/main/java/journeymap/client/render/texture/TextureImpl.java
+++ b/src/main/java/journeymap/client/render/texture/TextureImpl.java
@@ -17,7 +17,7 @@ import org.lwjgl.opengl.GL11;
 import java.awt.image.BufferedImage;
 import java.awt.image.DataBufferInt;
 import java.nio.ByteBuffer;
-import java.util.Arrays;
+import java.nio.ByteOrder;
 import java.util.concurrent.locks.ReentrantLock;
 
 public class TextureImpl extends AbstractTexture
@@ -111,7 +111,7 @@ public class TextureImpl extends AbstractTexture
 
             if (buffer == null || buffer.capacity() != bufferSize)
             {
-                buffer = ByteBuffer.allocateDirect(bufferSize);
+                buffer = ByteBuffer.allocateDirect(bufferSize).order(ByteOrder.BIG_ENDIAN);
             }
             buffer.clear();
 
@@ -126,10 +126,6 @@ public class TextureImpl extends AbstractTexture
                 if (pixelBuffer == null || pixelBuffer.length != pixelAmount)
                 {
                     pixelBuffer = new int[pixelAmount];
-                }
-                else
-                {
-                    Arrays.fill(pixelBuffer, 0);
                 }
 
                 pixels = bufferedImage.getRGB(0, 0, width, height, pixelBuffer, 0, width);

--- a/src/main/java/journeymap/client/task/multi/MapRegionTask.java
+++ b/src/main/java/journeymap/client/task/multi/MapRegionTask.java
@@ -214,7 +214,7 @@ public class MapRegionTask extends BaseMapTask
                         mapType = (time < 13800) ? MapType.day(player) : MapType.night(player);
                     }
 
-                    Boolean mapAll = params == null ? false : (Boolean) params;
+                    boolean mapAll = params == null ? false : (boolean) params;
 
                     regionLoader = new RegionLoader(minecraft, mapType, mapAll);
                     if (regionLoader.getRegionsFound() == 0)

--- a/src/main/java/journeymap/client/ui/dialog/GridEditor.java
+++ b/src/main/java/journeymap/client/ui/dialog/GridEditor.java
@@ -44,7 +44,7 @@ public class GridEditor extends JmUI
     private IntSliderButton buttonOpacity;
     private CheckBox checkDay, checkNight, checkUnderground;
     private ThemeToggle buttonDay, buttonNight, buttonUnderground;
-    private Integer activeColor;
+    private int activeColor;
     private MapType activeMapType;
 
     private Button buttonReset;
@@ -68,8 +68,7 @@ public class GridEditor extends JmUI
 
         this.gridSpecs = JourneymapClient.getCoreProperties().gridSpecs.clone();
 
-        MapType mapType = MapType.day(0);
-        activeMapType = mapType;
+        activeMapType = MapType.day(0);
         this.activeColor = this.gridSpecs.getSpec(activeMapType).getColor();
 
         Keyboard.enableRepeatEvents(true);

--- a/src/main/java/journeymap/client/ui/waypoint/WaypointEditor.java
+++ b/src/main/java/journeymap/client/ui/waypoint/WaypointEditor.java
@@ -459,15 +459,14 @@ public class WaypointEditor extends JmUI
         }
     }
 
-    protected void setFormColor(Integer color)
+    protected void setFormColor(int color)
     {
         //if(color!=null && color.equals(currentColor)) return;
 
         currentColor = color;
-        int[] c = RGB.ints(color);
-        fieldR.setText(Integer.toString(c[0]));
-        fieldG.setText(Integer.toString(c[1]));
-        fieldB.setText(Integer.toString(c[2]));
+        fieldR.setText(Integer.toString((color >> 16) & 0xFF));
+        fieldG.setText(Integer.toString((color >> 8) & 0xFF));
+        fieldB.setText(Integer.toString((color) & 0xFF));
         updateWaypointFromForm();
     }
 

--- a/src/main/java/journeymap/common/Journeymap.java
+++ b/src/main/java/journeymap/common/Journeymap.java
@@ -39,6 +39,7 @@ public class Journeymap
 {
     public static final String MOD_ID = "journeymap";
     public static final String SHORT_MOD_NAME = "JourneyMap";
+    private static final Logger LOGGER = LogManager.getLogger(MOD_ID);
     public static final Version JM_VERSION = Version.from(BuildInfo.MAJOR, BuildInfo.MINOR, BuildInfo.MICRO, BuildInfo.PATCH, new Version(5, 1, 4, "dev"));
     public static final String FORGE_VERSION = BuildInfo.FORGE_VERSION;
     public static final String WEBSITE_URL = "https://teamjm.github.io/journeymap-docs/";
@@ -56,7 +57,7 @@ public class Journeymap
      */
     public static Logger getLogger()
     {
-        return LogManager.getLogger(MOD_ID);
+        return LOGGER;
     }
 
     /**


### PR DESCRIPTION
## Optimize TextureImpl#setImage

This method is responsible for a lot of allocations during runtime mainly from creating a big pixel array `int[] pixels = new int[width * height];`.

What I did was the following:
- allocate the pixel array once and cache it into a field
- avoid calling `.getRGB` which makes a copy of the pixels and call `DataBufferInt#getData` instead when possible, note that as the javadoc says calling this method will disable some optimizations, idk if that's important ? Could use some reflection hacks to avoid disabling the optimizations.
- changed the 4 put byte calls to one putInt call
- changed the two for loops in one

## Optimize ChunkPainter

Instead of filling an internal array `int[][] colors = new int[16][16];` and then writing the pixels one by one into the `Graphics2D` object, I made it write directly to the internal array of a `BufferedImage`, and then used a single draw call to write into the `Graphics2D` instead of 256 calls.

## Cache the Logger

<img width="1662" height="375" alt="image" src="https://github.com/user-attachments/assets/6556d23b-5914-4f8c-9699-5d995afadaa0" />

## Use int colors instead of RGB arrays

Removes these allocations:

<img width="1652" height="527" alt="image" src="https://github.com/user-attachments/assets/ddb58bee-9e50-4401-a495-bb28f3563644" />



# Before
<img width="1666" height="827" alt="image" src="https://github.com/user-attachments/assets/f99a6e34-018c-4431-9bd7-0ed68d970ebc" />

# After
<img width="1658" height="840" alt="image" src="https://github.com/user-attachments/assets/937aada2-1cfe-4584-bdac-846412173458" />
