### PR TITLE
Fix slider keyboard navigation in settings

### DIFF
--- a/doc/changelog.html
+++ b/doc/changelog.html
@@ -25,4 +25,6 @@
 <ul>
     <li>Fix: biome label under minimap compass now updates instantly instead of with up to ~1400ms delay. (Eldrinn-Elantey)</li>
     <li>Fix: replace internal sun.awt.image.IntegerComponentRaster with standard Java API in PixelPaint. (Eldrinn-Elantey)</li>
+    <li>Fix: arrow keys in settings now control the slider under the cursor instead of always the first enabled slider. (Eldrinn-Elantey)</li>
+    <li>Fix: double sliders no longer lose precision when dragged. (Eldrinn-Elantey)</li>
 </ul>

--- a/src/main/java/journeymap/client/ui/component/DoubleSliderButton.java
+++ b/src/main/java/journeymap/client/ui/component/DoubleSliderButton.java
@@ -123,8 +123,8 @@ public class DoubleSliderButton extends Button implements IPropertyHolder<Atomic
             sliderValue = 1.0F;
         }
 
-        int intVal = (int) Math.round(sliderValue * (maxValue - minValue) + minValue);
-        setValue(intVal);
+        double val = sliderValue * (maxValue - minValue) + minValue;
+        setValue(val);
     }
 
     public void updateLabel()

--- a/src/main/java/journeymap/client/ui/component/IntSliderButton.java
+++ b/src/main/java/journeymap/client/ui/component/IntSliderButton.java
@@ -166,7 +166,7 @@ public class IntSliderButton extends Button implements IPropertyHolder<AtomicInt
 
     public boolean keyTyped(char c, int i)
     {
-        if (this.isEnabled())
+        if (this.isEnabled() && this.isMouseOver())
         {
             if (i == Keyboard.KEY_LEFT || i == Keyboard.KEY_DOWN || i == Keyboard.KEY_SUBTRACT)
             {


### PR DESCRIPTION
## Summary
- `IntSliderButton.keyTyped`: replaced `isEnabled()` check with `isEnabled() && isMouseOver()` — arrow keys now control the slider under the cursor instead of always targeting the first enabled slider on the page
- `DoubleSliderButton.setSliderValue`: removed `double → int` cast, values are now stored with full double precision when dragging