### PR TITLE
fix: add doRenderNoFade for third-party beacon rendering

### DIFF
--- a/doc/changelog.html
+++ b/doc/changelog.html
@@ -23,6 +23,7 @@
 
 <p>New in ${version}</p>
 <ul>
+    <li>Fix: add doRenderNoFade() for third-party mods to render waypoint beacons without distance-based fade. (Eldrinn-Elantey)</li>
     <li>Fix: biome label under minimap compass now updates instantly instead of with up to ~1400ms delay. (Eldrinn-Elantey)</li>
     <li>Fix: replace internal sun.awt.image.IntegerComponentRaster with standard Java API in PixelPaint. (Eldrinn-Elantey)</li>
 </ul>

--- a/src/main/java/journeymap/client/render/ingame/RenderWaypointBeacon.java
+++ b/src/main/java/journeymap/client/render/ingame/RenderWaypointBeacon.java
@@ -93,10 +93,20 @@ public class RenderWaypointBeacon
 
     static void doRender(Waypoint waypoint)
     {
-        doRender(waypoint, 1.0F);
+        doRender(waypoint, 1.0F, false);
+    }
+
+    static void doRenderNoFade(Waypoint waypoint)
+    {
+        doRender(waypoint, 1.0F, true);
     }
 
     static void doRender(Waypoint waypoint, float partialTicks)
+    {
+        doRender(waypoint, partialTicks, false);
+    }
+
+    static void doRender(Waypoint waypoint, float partialTicks, boolean skipFade)
     {
         if (renderManager.livingPlayer == null)
         {
@@ -122,11 +132,18 @@ public class RenderWaypointBeacon
             // Get view distance from waypoint
             final double actualDistance = playerVec.distanceTo(waypointVec);
 
-            final double fadeStartDistance = waypointProperties.beaconFadeStart.get();
-            final double fadeEndDistance = waypointProperties.beaconFadeEnd.get();
-
-            final double horizontalDistance = getHorizontalDistance(playerVec, waypointVec);
-            final float fadeAlpha = getFadeAlpha(horizontalDistance, fadeStartDistance, fadeEndDistance);
+            final float fadeAlpha;
+            if (skipFade)
+            {
+                fadeAlpha = 1.0F;
+            }
+            else
+            {
+                final double fadeStartDistance = waypointProperties.beaconFadeStart.get();
+                final double fadeEndDistance = waypointProperties.beaconFadeEnd.get();
+                final double horizontalDistance = getHorizontalDistance(playerVec, waypointVec);
+                fadeAlpha = getFadeAlpha(horizontalDistance, fadeStartDistance, fadeEndDistance);
+            }
             if (fadeAlpha <= MIN_VISIBLE_ALPHA)
             {
                 return;


### PR DESCRIPTION
Add doRenderNoFade() method to RenderWaypointBeacon to allow external mods to render waypoint beacons without distance-based fade. Refactor doRender() to accept a skipFade flag internally.