### PR TITLE
Fix Fatal error due to openGL bind on webmap thread

### DIFF
--- a/doc/changelog.html
+++ b/doc/changelog.html
@@ -23,5 +23,5 @@
 
 <p>New in ${version}</p>
 <ul>
-    <li>Fixed: weird crash when journeymap tried to pull text from window title, removed the logic to do that.</li>
+    <li>Fixed: Fatal error due to openGL bind on web map thread.</li>
 </ul>

--- a/src/main/java/journeymap/client/render/texture/TextureCache.java
+++ b/src/main/java/journeymap/client/render/texture/TextureCache.java
@@ -103,7 +103,7 @@ public class TextureCache
                     {
                         tex.queueForDeletion();
                     }
-                    tex = new TextureImpl(img, retain);
+                    tex = new TextureImpl(null, img, retain, false);
                     tex.setDescription(String.format("%s (%s)", name, filename));
                     namedTextures.put(name, tex);
                 }
@@ -293,7 +293,7 @@ public class TextureCache
                     {
                         tex.queueForDeletion();
                     }
-                    tex = new TextureImpl(img);
+                    tex = new TextureImpl(null, img, false, false);
                     entityIcons.put(texName, tex);
                 }
             }


### PR DESCRIPTION
Closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/23798

Took some time to dig properly at how TextureImpl work and turn you can call it in a safe way.
That's even how `getPlayerSkin` do it already.

There are a few other cases in this class but they don't seem to be used from the webmap so it should be ok I suppose.