### PR TITLE
Fix 'New Waypoint' textfield after searchbox entry

### DIFF
--- a/doc/changelog.html
+++ b/doc/changelog.html
@@ -23,5 +23,5 @@
 
 <p>New in ${version}</p>
 <ul>
-    <li></li>
+    <li>Fixed: New waypoint textbox refuses entry whilst waypoint searchbox is focused.</li>
 </ul>

--- a/src/main/java/journeymap/client/ui/waypoint/WaypointManager.java
+++ b/src/main/java/journeymap/client/ui/waypoint/WaypointManager.java
@@ -454,6 +454,7 @@ public class WaypointManager extends JmUI
         }
         if (guibutton == buttonAdd)
         {
+            searchBox.setFocused(false);
             Waypoint waypoint = Waypoint.of(mc.thePlayer);
             UIManager.getInstance().openWaypointEditor(waypoint, true, this);
             return;


### PR DESCRIPTION
When waypoint list searchbox is focused and user hits "New...", the New Waypoint name textfield refuses text input due to how keyinputs are handled in WaypointEditor, this just unfocuses the searchbox field when "New..." button is pressed.